### PR TITLE
Remove previous params

### DIFF
--- a/mindmeld/app_manager.py
+++ b/mindmeld/app_manager.py
@@ -117,9 +117,9 @@ class ApplicationManager:
 
     def _pre_dm(self, processed_query, context, params, frame, history):
         request = self.request_class(context=context, history=history, frame=frame,
-                                     params=FrozenParams(previous_params=params), **processed_query)
+                                     params=params, **processed_query)
 
-        response = self.responder_class(frame=frame, params=Params(previous_params=params),
+        response = self.responder_class(frame=frame, params=Params(),
                                         slots={}, history=history, request=request,
                                         directives=[])
         return request, response
@@ -167,6 +167,7 @@ class ApplicationManager:
         request, response = self._pre_dm(processed_query=processed_query,
                                          context=context, history=history,
                                          frame=frame, params=params)
+
         dm_response = self.dialogue_manager.apply_handler(request, response, **dm_params)
         response = self._post_dm(request, dm_response)
         return response
@@ -212,6 +213,7 @@ class ApplicationManager:
         request, response = self._pre_dm(processed_query=processed_query,
                                          context=context, history=history,
                                          frame=frame, params=params)
+
         dm_response = await self.dialogue_manager.apply_handler(request, response, **dm_params)
         response = self._post_dm(request, dm_response)
 

--- a/mindmeld/app_manager.py
+++ b/mindmeld/app_manager.py
@@ -116,9 +116,11 @@ class ApplicationManager:
         self.nlp.load()
 
     def _pre_dm(self, processed_query, context, params, frame, history):
+        # We pass in the previous turn's responder's params to the current request
         request = self.request_class(context=context, history=history, frame=frame,
                                      params=params, **processed_query)
 
+        # We reset the current turn's responder's params
         response = self.responder_class(frame=frame, params=Params(),
                                         slots={}, history=history, request=request,
                                         directives=[])

--- a/mindmeld/components/request.py
+++ b/mindmeld/components/request.py
@@ -51,11 +51,12 @@ def _validate_generic(name, ptype):
 
 
 PARAM_VALIDATORS = {
-    'allowed_intents': _validate_generic('allowed_intents', list),
+    'allowed_intents': _validate_generic('allowed_intents', tuple),
     'target_dialogue_state': _validate_generic('target_dialogue_state', str),
     'time_zone': _validate_time_zone,
     'timestamp': _validate_generic('timestamp', int),
-    'dynamic_resource': _validate_generic('dynamic_resource', dict)
+    'dynamic_resource': _validate_generic('dynamic_resource', immutables.Map)
+    'user_state': _validate_generic('user_state', immutables.Map)
 }
 
 
@@ -65,7 +66,6 @@ class Params:
     A class that contains parameters that modify how the user query is parsed.
 
     Attributes:
-        previous_params (dict): Dictionary for storing information across dialogue turns.
         allowed_intents (list, str): A list of intents that you can set to force the language
             processor to choose from.
         target_dialogue_state (str): The name of the dialogue handler that you want to reach in
@@ -75,13 +75,14 @@ class Params:
         timestamp (long): A unix time stamp for the request accurate to the nearest second.
         dynamic_resource (dict): A dictionary containing data used to influence the language
             classifiers by adding resource data for the given turn.
+       user_state (dict): User defined key-value pair state.
     """
-    previous_params = attr.ib(default=None)
-    allowed_intents = attr.ib(default=[])
+    allowed_intents = attr.ib(default=tuple())
     target_dialogue_state = attr.ib(default=None)
     time_zone = attr.ib(default=None)
     timestamp = attr.ib(default=0)
     dynamic_resource = attr.ib(default={})
+    user_state = attr.ib(default={})
 
     def validate_param(self, name):
         """
@@ -137,7 +138,6 @@ class FrozenParams(Params):
     An immutable version of the Params object.
 
     Attributes:
-        previous_params (dict): Dictionary for storing information across dialogue turns.
         allowed_intents (list, str): A list of intents that you can set to force the language
             processor to choose from.
         target_dialogue_state (str): The name of the dialogue handler that you want to reach in
@@ -148,7 +148,6 @@ class FrozenParams(Params):
         dynamic_resource (dict): A dictionary containing data used to influence the language
             classifiers by adding resource data for the given turn.
     """
-    previous_params = attr.ib(default=None)
     allowed_intents = attr.ib(default=tuple(), converter=tuple)
     target_dialogue_state = attr.ib(default=None)
     time_zone = attr.ib(default=None)

--- a/mindmeld/components/request.py
+++ b/mindmeld/components/request.py
@@ -56,7 +56,6 @@ PARAM_VALIDATORS = {
     'time_zone': _validate_time_zone,
     'timestamp': _validate_generic('timestamp', int),
     'dynamic_resource': _validate_generic('dynamic_resource', immutables.Map)
-    'user_state': _validate_generic('user_state', immutables.Map)
 }
 
 
@@ -75,14 +74,12 @@ class Params:
         timestamp (long): A unix time stamp for the request accurate to the nearest second.
         dynamic_resource (dict): A dictionary containing data used to influence the language
             classifiers by adding resource data for the given turn.
-       user_state (dict): User defined key-value pair state.
     """
-    allowed_intents = attr.ib(default=tuple())
+    allowed_intents = attr.ib(default=attr.Factory(tuple))
     target_dialogue_state = attr.ib(default=None)
     time_zone = attr.ib(default=None)
     timestamp = attr.ib(default=0)
-    dynamic_resource = attr.ib(default={})
-    user_state = attr.ib(default={})
+    dynamic_resource = attr.ib(default=attr.Factory(dict))
 
     def validate_param(self, name):
         """
@@ -148,7 +145,8 @@ class FrozenParams(Params):
         dynamic_resource (dict): A dictionary containing data used to influence the language
             classifiers by adding resource data for the given turn.
     """
-    allowed_intents = attr.ib(default=tuple(), converter=tuple)
+    allowed_intents = attr.ib(default=attr.Factory(tuple),
+                              converter=tuple)
     target_dialogue_state = attr.ib(default=None)
     time_zone = attr.ib(default=None)
     timestamp = attr.ib(default=0)
@@ -184,8 +182,10 @@ class Request:
     """
     domain = attr.ib(default=None)
     intent = attr.ib(default=None)
-    entities = attr.ib(default=tuple(), converter=tuple)
-    history = attr.ib(default=tuple(), converter=tuple)
+    entities = attr.ib(default=attr.Factory(tuple),
+                       converter=tuple)
+    history = attr.ib(default=attr.Factory(tuple),
+                      converter=tuple)
     text = attr.ib(default=None)
     frame = attr.ib(default=immutables.Map(),
                     converter=immutables.Map)
@@ -194,6 +194,9 @@ class Request:
                       converter=immutables.Map)
     confidences = attr.ib(default=immutables.Map(),
                           converter=immutables.Map)
-    nbest_transcripts_text = attr.ib(default=tuple(), converter=tuple)
-    nbest_transcripts_entities = attr.ib(default=tuple(), converter=tuple)
-    nbest_aligned_entities = attr.ib(default=tuple(), converter=tuple)
+    nbest_transcripts_text = attr.ib(default=attr.Factory(tuple),
+                                     converter=tuple)
+    nbest_transcripts_entities = attr.ib(default=attr.Factory(tuple),
+                                         converter=tuple)
+    nbest_aligned_entities = attr.ib(default=attr.Factory(tuple),
+                                     converter=tuple)

--- a/source/quickstart/10_deploy_to_production.rst
+++ b/source/quickstart/10_deploy_to_production.rst
@@ -41,137 +41,517 @@ To test using any REST client (such as Postman or Advanced Rest Client), send `P
 
 .. code-block:: console
 
-  curl -X POST -H 'Content-Type: application/json' -d '{"text": "hello world"}' "http://localhost:7150/parse" | jq .
+  curl -X POST -H 'Content-Type: application/json' -d '{"text": "order from firetrail"}' "http://localhost:7150/parse" | jq .
+
+.. note:: The MindMeld flask server is stateless, so in order to perform multi-turn dialogues with the server, copy the response returned from the server in the first turn and use that in the data parameter of the curl request in the next turn, along with the new ``text`` key, value.
 
 .. code-block:: console
 
-  {
-    "dialogue_state": "welcome",
-    "directives": [
-      {
-        "name": "reply",
-        "payload": {
-          "text": "Hello. I can help you find store hours for your local Kwik-E-Mart. How can I help?"
-        },
-        "type": "view"
-      },
-      {
-        "name": "listen",
-        "type": "action"
-      }
-    ],
-    "frame": {},
-    "history": [
-      {
-        "dialogue_state": "welcome",
-        "directives": [
-          {
-            "name": "reply",
-            "payload": {
-              "text": "Hello. I can help you find store hours for your local Kwik-E-Mart. How can I help?"
-            },
-            "type": "view"
-          },
-          {
-            "name": "listen",
-            "type": "action"
-          }
-        ],
-        "frame": {},
-        "params": {
-          "allowed_intents": [],
-          "dynamic_resource": {},
-          "previous_params": {
-            "allowed_intents": [],
-            "dynamic_resource": {},
-            "previous_params": null,
-            "target_dialogue_state": null,
-            "time_zone": null,
-            "timestamp": 0
-          },
-          "target_dialogue_state": null,
-          "time_zone": null,
-          "timestamp": 0
-        },
-        "request": {
-          "confidences": {},
-          "context": {},
-          "domain": "store_info",
-          "entities": [],
-          "frame": {},
-          "history": [],
-          "intent": "greet",
-          "nbest_aligned_entities": [],
-          "nbest_transcripts_entities": [],
-          "nbest_transcripts_text": [],
-          "params": {
-            "allowed_intents": [],
-            "dynamic_resource": {},
-            "previous_params": {
-              "allowed_intents": [],
-              "dynamic_resource": {},
-              "previous_params": null,
-              "target_dialogue_state": null,
-              "time_zone": null,
-              "timestamp": 0
-            },
-            "target_dialogue_state": null,
-            "time_zone": null,
-            "timestamp": 0
-          },
-          "text": "hello world"
-        },
-        "slots": {}
-      }
-    ],
-    "params": {
-      "allowed_intents": [],
-      "dynamic_resource": {},
-      "previous_params": {
-        "allowed_intents": [],
-        "dynamic_resource": {},
-        "previous_params": null,
-        "target_dialogue_state": null,
-        "time_zone": null,
-        "timestamp": 0
-      },
-      "target_dialogue_state": null,
-      "time_zone": null,
-      "timestamp": 0
-    },
-    "request": {
-      "confidences": {},
-      "context": {},
-      "domain": "store_info",
-      "entities": [],
-      "frame": {},
-      "history": [],
-      "intent": "greet",
-      "nbest_aligned_entities": [],
-      "nbest_transcripts_entities": [],
-      "nbest_transcripts_text": [],
-      "params": {
-        "allowed_intents": [],
-        "dynamic_resource": {},
-        "previous_params": {
-          "allowed_intents": [],
-          "dynamic_resource": {},
-          "previous_params": null,
-          "target_dialogue_state": null,
-          "time_zone": null,
-          "timestamp": 0
-        },
-        "target_dialogue_state": null,
-        "time_zone": null,
-        "timestamp": 0
-      },
-      "text": "hello world"
-    },
-    "request_id": "38dd4c17-1440-492c-8d4b-eeacd7e108e6",
-    "slots": {},
-    "response_time": 0.018073081970214844,
-    "version": "2.0"
-  }
+   {
+     "dialogue_state": "build_order",
+     "directives": [
+       {
+         "name": "reply",
+         "payload": {
+           "text": "Great, what would you like to order from Firetrail Pizza?"
+         },
+         "type": "view"
+       },
+       {
+         "name": "listen",
+         "type": "action"
+       }
+     ],
+     "frame": {
+       "dishes": [],
+       "restaurant": {
+         "categories": [
+           "Beverages",
+           "Pizzas",
+           "Sides",
+           "Popular Dishes"
+         ],
+         "cuisine_types": [
+           "Pizza"
+         ],
+         "id": "B01CT54GYE",
+         "image_url": "https://images-na.ssl-images-amazon.com/images/G/01/ember/restaurants/SanFrancisco/FiretrailPizza/logo_232x174._CB295435423_SX600_QL70_.png",
+         "menus": [
+           {
+             "id": "127c097e-2d9d-4880-99ac-f1688909af07",
+             "option_groups": [
+               {
+                 "id": "ToppingsGF",
+                 "max_selected": 9,
+                 "min_selected": 0,
+                 "name": "Add Some Extra Toppings",
+                 "options": [
+                   {
+                     "description": null,
+                     "id": "B01D8TDFV0",
+                     "name": "Goat Cheese",
+                     "price": 2
+                   },
+                   {
+                     "description": null,
+                     "id": "B01D8TCH3M",
+                     "name": "Olives",
+                     "price": 1
+                   },
+                   {
+                     "description": null,
+                     "id": "B01D8TD8VC",
+                     "name": "Garlic",
+                     "price": 1
+                   },
+                   {
+                     "description": null,
+                     "id": "B01D8TD4YI",
+                     "name": "Sausage",
+                     "price": 2
+                   },
+                   {
+                     "description": null,
+                     "id": "B01D8TD5J2",
+                     "name": "Onions",
+                     "price": 1
+                   },
+                   {
+                     "description": null,
+                     "id": "B01D8TDHAY",
+                     "name": "Bruno Nippy Peppers",
+                     "price": 1
+                   },
+                   {
+                     "description": null,
+                     "id": "B01D8TDALK",
+                     "name": "Pepperoni",
+                     "price": 1
+                   },
+                   {
+                     "description": null,
+                     "id": "B01D8TCT7G",
+                     "name": "Roasted Red Peppers",
+                     "price": 1
+                   },
+                   {
+                     "description": null,
+                     "id": "B01D8TCWXC",
+                     "name": "Mushrooms",
+                     "price": 1
+                   }
+                 ]
+               },
+               {
+                 "id": "Toppings",
+                 "max_selected": 12,
+                 "min_selected": 0,
+                 "name": "Add Some Extra Toppings",
+                 "options": [
+                   {
+                     "description": null,
+                     "id": "B01D8TCVYC",
+                     "name": "Roasted Red Peppers",
+                     "price": 1
+                   },
+                   {
+                     "description": null,
+                     "id": "B01D8TDF9M",
+                     "name": "Garlic",
+                     "price": 1
+                   },
+                   {
+                     "description": null,
+                     "id": "B01D8TCWM8",
+                     "name": "Olives",
+                     "price": 1
+                   },
+                   {
+                     "description": null,
+                     "id": "B01D8TC930",
+                     "name": "Basil",
+                     "price": 1
+                   },
+                   {
+                     "description": null,
+                     "id": "B01D8TDBFK",
+                     "name": "Goat Cheese",
+                     "price": 2
+                   },
+                   {
+                     "description": null,
+                     "id": "B01D8TCKHU",
+                     "name": "Sausage",
+                     "price": 2
+                   },
+                   {
+                     "description": null,
+                     "id": "B01D8TCSNG",
+                     "name": "Onions",
+                     "price": 1
+                   },
+                   {
+                     "description": null,
+                     "id": "B01D8TCO2G",
+                     "name": "Bruno Nippy Peppers",
+                     "price": 1
+                   },
+                   {
+                     "description": null,
+                     "id": "B01D8TC8AE",
+                     "name": "Pepperoni",
+                     "price": 2
+                   },
+                   {
+                     "description": null,
+                     "id": "B01D8TCJRQ",
+                     "name": "Mushrooms",
+                     "price": 2
+                   },
+                   {
+                     "description": null,
+                     "id": "B01D8TC8PE",
+                     "name": "Shredded Parmesan",
+                     "price": 2
+                   },
+                   {
+                     "description": null,
+                     "id": "B01D8TD560",
+                     "name": "Shredded Mozzarella",
+                     "price": 2
+                   }
+                 ]
+               }
+             ],
+             "size_groups": [
+               {
+                 "description": null,
+                 "id": "Pizzasize",
+                 "name": "Choose Your Pizza Size",
+                 "sizes": [
+                   {
+                     "alt_name": "10\" Pizza",
+                     "name": "10\" Pizza"
+                   },
+                   {
+                     "alt_name": "14\" Pizza",
+                     "name": "14\" Pizza"
+                   }
+                 ]
+               }
+             ]
+           }
+         ],
+         "name": "Firetrail Pizza",
+         "num_reviews": 13,
+         "price_range": 2,
+         "rating": 4.1
+       }
+     },
+     "history": [
+       {
+         "dialogue_state": "build_order",
+         "directives": [
+           {
+             "name": "reply",
+             "payload": {
+               "text": "Great, what would you like to order from Firetrail Pizza?"
+             },
+             "type": "view"
+           },
+           {
+             "name": "listen",
+             "type": "action"
+           }
+         ],
+         "frame": {
+           "dishes": [],
+           "restaurant": {
+             "categories": [
+               "Beverages",
+               "Pizzas",
+               "Sides",
+               "Popular Dishes"
+             ],
+             "cuisine_types": [
+               "Pizza"
+             ],
+             "id": "B01CT54GYE",
+             "image_url": "https://images-na.ssl-images-amazon.com/images/G/01/ember/restaurants/SanFrancisco/FiretrailPizza/logo_232x174._CB295435423_SX600_QL70_.png",
+             "menus": [
+               {
+                 "id": "127c097e-2d9d-4880-99ac-f1688909af07",
+                 "option_groups": [
+                   {
+                     "id": "ToppingsGF",
+                     "max_selected": 9,
+                     "min_selected": 0,
+                     "name": "Add Some Extra Toppings",
+                     "options": [
+                       {
+                         "description": null,
+                         "id": "B01D8TDFV0",
+                         "name": "Goat Cheese",
+                         "price": 2
+                       },
+                       {
+                         "description": null,
+                         "id": "B01D8TCH3M",
+                         "name": "Olives",
+                         "price": 1
+                       },
+                       {
+                         "description": null,
+                         "id": "B01D8TD8VC",
+                         "name": "Garlic",
+                         "price": 1
+                       },
+                       {
+                         "description": null,
+                         "id": "B01D8TD4YI",
+                         "name": "Sausage",
+                         "price": 2
+                       },
+                       {
+                         "description": null,
+                         "id": "B01D8TD5J2",
+                         "name": "Onions",
+                         "price": 1
+                       },
+                       {
+                         "description": null,
+                         "id": "B01D8TDHAY",
+                         "name": "Bruno Nippy Peppers",
+                         "price": 1
+                       },
+                       {
+                         "description": null,
+                         "id": "B01D8TDALK",
+                         "name": "Pepperoni",
+                         "price": 1
+                       },
+                       {
+                         "description": null,
+                         "id": "B01D8TCT7G",
+                         "name": "Roasted Red Peppers",
+                         "price": 1
+                       },
+                       {
+                         "description": null,
+                         "id": "B01D8TCWXC",
+                         "name": "Mushrooms",
+                         "price": 1
+                       }
+                     ]
+                   },
+                   {
+                     "id": "Toppings",
+                     "max_selected": 12,
+                     "min_selected": 0,
+                     "name": "Add Some Extra Toppings",
+                     "options": [
+                       {
+                         "description": null,
+                         "id": "B01D8TCVYC",
+                         "name": "Roasted Red Peppers",
+                         "price": 1
+                       },
+                       {
+                         "description": null,
+                         "id": "B01D8TDF9M",
+                         "name": "Garlic",
+                         "price": 1
+                       },
+                       {
+                         "description": null,
+                         "id": "B01D8TCWM8",
+                         "name": "Olives",
+                         "price": 1
+                       },
+                       {
+                         "description": null,
+                         "id": "B01D8TC930",
+                         "name": "Basil",
+                         "price": 1
+                       },
+                       {
+                         "description": null,
+                         "id": "B01D8TDBFK",
+                         "name": "Goat Cheese",
+                         "price": 2
+                       },
+                       {
+                         "description": null,
+                         "id": "B01D8TCKHU",
+                         "name": "Sausage",
+                         "price": 2
+                       },
+                       {
+                         "description": null,
+                         "id": "B01D8TCSNG",
+                         "name": "Onions",
+                         "price": 1
+                       },
+                       {
+                         "description": null,
+                         "id": "B01D8TCO2G",
+                         "name": "Bruno Nippy Peppers",
+                         "price": 1
+                       },
+                       {
+                         "description": null,
+                         "id": "B01D8TC8AE",
+                         "name": "Pepperoni",
+                         "price": 2
+                       },
+                       {
+                         "description": null,
+                         "id": "B01D8TCJRQ",
+                         "name": "Mushrooms",
+                         "price": 2
+                       },
+                       {
+                         "description": null,
+                         "id": "B01D8TC8PE",
+                         "name": "Shredded Parmesan",
+                         "price": 2
+                       },
+                       {
+                         "description": null,
+                         "id": "B01D8TD560",
+                         "name": "Shredded Mozzarella",
+                         "price": 2
+                       }
+                     ]
+                   }
+                 ],
+                 "size_groups": [
+                   {
+                     "description": null,
+                     "id": "Pizzasize",
+                     "name": "Choose Your Pizza Size",
+                     "sizes": [
+                       {
+                         "alt_name": "10\" Pizza",
+                         "name": "10\" Pizza"
+                       },
+                       {
+                         "alt_name": "14\" Pizza",
+                         "name": "14\" Pizza"
+                       }
+                     ]
+                   }
+                 ]
+               }
+             ],
+             "name": "Firetrail Pizza",
+             "num_reviews": 13,
+             "price_range": 2,
+             "rating": 4.1
+           }
+         },
+         "params": {
+           "allowed_intents": [],
+           "dynamic_resource": {},
+           "target_dialogue_state": null,
+           "time_zone": null,
+           "timestamp": 0
+         },
+         "request": {
+           "confidences": {},
+           "context": {},
+           "domain": "ordering",
+           "entities": [
+             {
+               "role": null,
+               "span": {
+                 "end": 19,
+                 "start": 11
+               },
+               "text": "firetrail",
+               "type": "restaurant",
+               "value": [
+                 {
+                   "cname": "Firetrail Pizza",
+                   "id": "B01CT54GYE",
+                   "score": 27.906038,
+                   "top_synonym": "Firetrail"
+                 }
+               ]
+             }
+           ],
+           "frame": {},
+           "history": [],
+           "intent": "build_order",
+           "nbest_aligned_entities": [],
+           "nbest_transcripts_entities": [],
+           "nbest_transcripts_text": [],
+           "params": {
+             "allowed_intents": [],
+             "dynamic_resource": {},
+             "target_dialogue_state": null,
+             "time_zone": null,
+             "timestamp": 0
+           },
+           "text": "order from firetrail"
+         },
+         "slots": {
+           "restaurant_name": "Firetrail Pizza"
+         }
+       }
+     ],
+     "params": {
+       "allowed_intents": [],
+       "dynamic_resource": {},
+       "target_dialogue_state": null,
+       "time_zone": null,
+       "timestamp": 0
+     },
+     "request": {
+       "confidences": {},
+       "context": {},
+       "domain": "ordering",
+       "entities": [
+         {
+           "role": null,
+           "span": {
+             "end": 19,
+             "start": 11
+           },
+           "text": "firetrail",
+           "type": "restaurant",
+           "value": [
+             {
+               "cname": "Firetrail Pizza",
+               "id": "B01CT54GYE",
+               "score": 27.906038,
+               "top_synonym": "Firetrail"
+             }
+           ]
+         }
+       ],
+       "frame": {},
+       "history": [],
+       "intent": "build_order",
+       "nbest_aligned_entities": [],
+       "nbest_transcripts_entities": [],
+       "nbest_transcripts_text": [],
+       "params": {
+         "allowed_intents": [],
+         "dynamic_resource": {},
+         "target_dialogue_state": null,
+         "time_zone": null,
+         "timestamp": 0
+       },
+       "text": "order from firetrail"
+     },
+     "request_id": "21473eb8-14c2-438a-9102-d8178104501f",
+     "slots": {
+       "restaurant_name": "Firetrail Pizza"
+     },
+     "response_time": 2.535576820373535,
+     "version": "2.0"
+   }
 
 The web service responds with a JSON data structure containing the application response along with the detailed output for all of the machine learning components of the MindMeld platform.
 

--- a/source/userguide/dm.rst
+++ b/source/userguide/dm.rst
@@ -159,10 +159,6 @@ The ``params`` attribute of the ``request`` object is an immutable :class:`Froze
 +------------------------------+-----------------------------------------------------------------------------------+
 | Attribute                    | Description                                                                       |
 +==============================+===================================================================================+
-|:data:`previous_params`       | Dictionary for storing information across dialogue turns. You can set custom      |
-|                              | key,value pairs that can be tracked across multiple dialogue turns                |
-|                              | (not for use by front-end clients)                                                |
-+------------------------------+-----------------------------------------------------------------------------------+
 | :data:`allowed_intents`      | A list of intents that you can set to force the language processor to choose      |
 |                              | from                                                                              |
 +------------------------------+-----------------------------------------------------------------------------------+

--- a/tests/components/test_dialogue.py
+++ b/tests/components/test_dialogue.py
@@ -246,6 +246,4 @@ def test_convo_params_are_cleared(kwik_e_mart_nlp, kwik_e_mart_app_path):
     convo.params = Params(allowed_intents=['store_info.find_nearest_store'],
                           target_dialogue_state='greeting')
     convo.say('close door')
-    assert convo.params == Params(previous_params=FrozenParams(
-        allowed_intents=('store_info.find_nearest_store',), target_dialogue_state='greeting'),
-        target_dialogue_state='send_store_hours_flow')
+    assert convo.params == Params()

--- a/tests/components/test_dialogue_async.py
+++ b/tests/components/test_dialogue_async.py
@@ -250,9 +250,7 @@ async def test_convo_params_are_cleared(async_kwik_e_mart_app, kwik_e_mart_app_p
         allowed_intents=['store_info.find_nearest_store'],
         target_dialogue_state='welcome')
     await convo.say('close door')
-    assert convo.params == Params(
-        previous_params=FrozenParams(allowed_intents=['store_info.find_nearest_store'],
-                                     target_dialogue_state='welcome'))
+    assert convo.params == Params()
 
 
 @pytest.mark.conversation

--- a/tests/kwik_e_mart/__init__.py
+++ b/tests/kwik_e_mart/__init__.py
@@ -15,6 +15,7 @@ def welcome(request, responder):
         prefix = 'Hello, {name}. '
     except KeyError:
         prefix = 'Hello. '
+
     responder.reply(prefix + 'I can help you find store hours '
                              'for your local Kwik-E-Mart. How can I help?')
     responder.listen()

--- a/tests/kwik_e_mart/app_async.py
+++ b/tests/kwik_e_mart/app_async.py
@@ -13,6 +13,7 @@ async def welcome(request, responder):
         prefix = 'Hello, {name}. '
     except KeyError:
         prefix = 'Hello. '
+
     responder.reply(prefix + 'I can help you find store hours '
                              'for your local Kwik-E-Mart. How can I help?')
     responder.listen()


### PR DESCRIPTION
This PR does the following:

1) Removes the `previous_params ` field since it is not being used in any application and I am unclear why we have it
2) Fix the bug where the request object does not persist the previous turn's responder