### PR TITLE
Fixed bug for intent classification reporting

### DIFF
--- a/mindmeld/components/nlp.py
+++ b/mindmeld/components/nlp.py
@@ -666,8 +666,8 @@ class DomainProcessor(Processor):
         if len(self.intents) > 1:
             intent_eval = self.intent_classifier.evaluate(label_set=label_set)
             if intent_eval:
-                print("Intent classification accuracy for the '%s' domain: %s",
-                      self.name, intent_eval.get_accuracy())
+                print("Intent classification accuracy for the '%s' domain: %s".format(
+                    self.name, intent_eval.get_accuracy()))
                 if print_stats:
                     intent_eval.print_stats()
             else:


### PR DESCRIPTION
Currently, we report the following:
`Intent classification accuracy for the '%s' domain: %s salary 1.0`