### PR TITLE
Reduce ES requirement for MindMeld

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ script:
   - mindmeld num-parse
   - ./lintme
   - mkdir ~/test-reports
-  - pytest --junitxml=~/test-reports/junit.xml --cov-report html --cov=mindmeld
+  - travis_wait 20 pytest --junitxml=~/test-reports/junit.xml --cov-report html --cov=mindmeld

--- a/mindmeld/components/nlp.py
+++ b/mindmeld/components/nlp.py
@@ -1134,7 +1134,7 @@ class EntityProcessor(Processor):
             self.role_classifier.load(incremental_model_path if incremental_timestamp else model_path)
             self.entity_resolver.load()
         except EntityResolverConnectionError:
-            logger.warning('Cannot connect to ES; Entity Resolver is not loaded.')
+            logger.warning('Cannot connect to ES, so Entity Resolver is not loaded.')
 
     def _evaluate(self, print_stats, label_set="test"):
         if len(self.role_classifier.roles) > 1:

--- a/mindmeld/components/nlp.py
+++ b/mindmeld/components/nlp.py
@@ -32,7 +32,7 @@ from ..resource_loader import ResourceLoader
 
 from .domain_classifier import DomainClassifier
 from .intent_classifier import IntentClassifier
-from .entity_resolver import EntityResolver
+from .entity_resolver import EntityResolver, EntityResolverConnectionError
 from .entity_recognizer import EntityRecognizer
 from .parser import Parser
 from .role_classifier import RoleClassifier
@@ -1128,10 +1128,13 @@ class EntityProcessor(Processor):
         self.role_classifier.dump(model_path, incremental_model_path=incremental_model_path)
 
     def _load(self, incremental_timestamp=None):
-        model_path, incremental_model_path = path.get_role_model_paths(
-            self._app_path, self.domain, self.intent, self.type, timestamp=incremental_timestamp)
-        self.role_classifier.load(incremental_model_path if incremental_timestamp else model_path)
-        self.entity_resolver.load()
+        try:
+            model_path, incremental_model_path = path.get_role_model_paths(
+                self._app_path, self.domain, self.intent, self.type, timestamp=incremental_timestamp)
+            self.role_classifier.load(incremental_model_path if incremental_timestamp else model_path)
+            self.entity_resolver.load()
+        except EntityResolverConnectionError:
+            logger.warning('Cannot connect to ES; Entity Resolver is not loaded.')
 
     def _evaluate(self, print_stats, label_set="test"):
         if len(self.role_classifier.roles) > 1:

--- a/source/conf.py
+++ b/source/conf.py
@@ -210,7 +210,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # the docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
 #
-html_favicon = 'favicon.ico'
+html_favicon = './_static/favicon.ico'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
A couple of things:

1. Catch and process EntityResolverConnectionError; ES should not be a strong requirement for MindMeld application to run.
2. Increase timeout for Travis.
3. Add the correct relative path for icon.