### PR TITLE
Fixing warning in console

### DIFF
--- a/mindmeld-ui/src/app/components/dialogue-manager-component.jsx
+++ b/mindmeld-ui/src/app/components/dialogue-manager-component.jsx
@@ -62,9 +62,9 @@ class DialogueManager extends Component {
                       {
                         replies.map((reply, index) => {
                           return (
-                            <Row>
+                            <Row key={index}>
                               <Col>
-                                <div className="reply" key={index}>{reply}</div>
+                                <div className="reply">{reply}</div>
                               </Col>
                             </Row>
                             )


### PR DESCRIPTION
It's a benign warning that I found when looking at another PR. 

The warning happens in the console if you open the dialogue manager section. It complains about a component not having a 'key' set.