### PR TITLE
Consolidated tokenization logic and added documentation details

### DIFF
--- a/mindmeld/components/classifier.py
+++ b/mindmeld/components/classifier.py
@@ -335,8 +335,7 @@ class Classifier(ABC):
                 query, time_zone=time_zone, timestamp=timestamp)
         return self._model.view_extracted_features(query, dynamic_resource)
 
-    @staticmethod
-    def _get_model_config(loaded_config=None, **kwargs):
+    def _get_model_config(self, loaded_config=None, **kwargs):
         """Updates the loaded configuration with runtime specified options, and creates a model
         configuration object with the final configuration dictionary. If an application config
         exists it should be passed in, if not the default config should be passed in.
@@ -346,6 +345,7 @@ class Classifier(ABC):
         """
         try:
             # If all params required for model config were passed in, use kwargs
+            kwargs['tokenizer'] = self._resource_loader.query_factory.tokenizer
             return ModelConfig(**kwargs)
         except (TypeError, ValueError):
             # Use application specified or default config, customizing with provided kwargs
@@ -416,6 +416,9 @@ class Classifier(ABC):
                 self._model.config.resolve_config(self._get_model_config())
 
             self._model.initialize_resources(self._resource_loader)
+
+            # We need to load the tokenizer from the app
+            self._model.config.tokenizer = self._resource_loader.query_factory.tokenizer
             self.config = ClassifierConfig.from_model_config(self._model.config)
 
         self.hash = self._load_hash(model_path)

--- a/mindmeld/components/classifier.py
+++ b/mindmeld/components/classifier.py
@@ -335,7 +335,8 @@ class Classifier(ABC):
                 query, time_zone=time_zone, timestamp=timestamp)
         return self._model.view_extracted_features(query, dynamic_resource)
 
-    def _get_model_config(self, loaded_config=None, **kwargs):
+    @staticmethod
+    def _get_model_config(loaded_config=None, **kwargs):
         """Updates the loaded configuration with runtime specified options, and creates a model
         configuration object with the final configuration dictionary. If an application config
         exists it should be passed in, if not the default config should be passed in.
@@ -345,7 +346,6 @@ class Classifier(ABC):
         """
         try:
             # If all params required for model config were passed in, use kwargs
-            kwargs['tokenizer'] = self._resource_loader.query_factory.tokenizer
             return ModelConfig(**kwargs)
         except (TypeError, ValueError):
             # Use application specified or default config, customizing with provided kwargs
@@ -416,9 +416,6 @@ class Classifier(ABC):
                 self._model.config.resolve_config(self._get_model_config())
 
             self._model.initialize_resources(self._resource_loader)
-
-            # We need to load the tokenizer from the app
-            self._model.config.tokenizer = self._resource_loader.query_factory.tokenizer
             self.config = ClassifierConfig.from_model_config(self._model.config)
 
         self.hash = self._load_hash(model_path)

--- a/mindmeld/components/dialogue.py
+++ b/mindmeld/components/dialogue.py
@@ -523,7 +523,8 @@ class DialogueFlow(DialogueManager):
 
         self._entrance_handler = _async_set_target_state if self.async_mode else _set_target_state
         app.add_dialogue_rule(self.name, self._entrance_handler, **kwargs)
-        handler = self._apply_flow_handler_async if self.async_mode else self._apply_flow_handler_sync
+        handler = \
+            self._apply_flow_handler_async if self.async_mode else self._apply_flow_handler_sync
         app.add_dialogue_rule(self.flow_state, handler, targeted_only=True)
 
     @property

--- a/mindmeld/components/dialogue.py
+++ b/mindmeld/components/dialogue.py
@@ -523,8 +523,8 @@ class DialogueFlow(DialogueManager):
 
         self._entrance_handler = _async_set_target_state if self.async_mode else _set_target_state
         app.add_dialogue_rule(self.name, self._entrance_handler, **kwargs)
-        handler = \
-            self._apply_flow_handler_async if self.async_mode else self._apply_flow_handler_sync
+        handler = self._apply_flow_handler_async if self.async_mode else \
+            self._apply_flow_handler_sync
         app.add_dialogue_rule(self.flow_state, handler, targeted_only=True)
 
     @property
@@ -563,9 +563,6 @@ class DialogueFlow(DialogueManager):
         except (IndexError, TypeError):
             # Support syntax: @middleware()
             return _decorator
-
-        self._entrance_handler = func
-        return func
 
     def handle(self, **kwargs):
         """The dialogue flow handler."""

--- a/mindmeld/components/entity_recognizer.py
+++ b/mindmeld/components/entity_recognizer.py
@@ -79,6 +79,7 @@ class EntityRecognizer(Classifier):
         logger.info('Fitting entity recognizer: domain=%r, intent=%r', self.domain, self.intent)
 
         # create model with given params
+        kwargs['tokenizer'] = self._resource_loader.query_factory.tokenizer
         self._model_config = self._get_model_config(**kwargs)
         model = create_model(self._model_config)
 
@@ -146,6 +147,7 @@ class EntityRecognizer(Classifier):
 
             self.entity_types = er_data['entity_types']
             self._model_config = er_data.get('model_config')
+            self._model_config.tokenizer = self._resource_loader.query_factory.tokenizer
 
             # The default is True since < MM 3.2.0 models are serializable by default
             is_serializable = er_data.get('serializable', True)
@@ -180,6 +182,8 @@ class EntityRecognizer(Classifier):
 
             self._model.register_resources(gazetteers=gazetteers, sys_types=sys_types,
                                            w_ngram_freq=w_ngram_freq, c_ngram_freq=c_ngram_freq)
+
+            self._model.config.tokenizer = self._resource_loader.query_factory.tokenizer
             self.config = ClassifierConfig.from_model_config(self._model.config)
 
         self.hash = self._load_hash(model_path)

--- a/mindmeld/components/entity_recognizer.py
+++ b/mindmeld/components/entity_recognizer.py
@@ -79,7 +79,6 @@ class EntityRecognizer(Classifier):
         logger.info('Fitting entity recognizer: domain=%r, intent=%r', self.domain, self.intent)
 
         # create model with given params
-        kwargs['tokenizer'] = self._resource_loader.query_factory.tokenizer
         self._model_config = self._get_model_config(**kwargs)
         model = create_model(self._model_config)
 
@@ -147,7 +146,6 @@ class EntityRecognizer(Classifier):
 
             self.entity_types = er_data['entity_types']
             self._model_config = er_data.get('model_config')
-            self._model_config.tokenizer = self._resource_loader.query_factory.tokenizer
 
             # The default is True since < MM 3.2.0 models are serializable by default
             is_serializable = er_data.get('serializable', True)
@@ -175,15 +173,15 @@ class EntityRecognizer(Classifier):
                 self._model.config.resolve_config(self._get_model_config())
 
             gazetteers = self._resource_loader.get_gazetteers()
+            tokenizer = self._resource_loader.get_tokenizer()
             sys_types = set((t for t in self.entity_types if Entity.is_system_entity(t)))
 
             w_ngram_freq = er_data.get('w_ngram_freq')
             c_ngram_freq = er_data.get('c_ngram_freq')
 
             self._model.register_resources(gazetteers=gazetteers, sys_types=sys_types,
-                                           w_ngram_freq=w_ngram_freq, c_ngram_freq=c_ngram_freq)
-
-            self._model.config.tokenizer = self._resource_loader.query_factory.tokenizer
+                                           w_ngram_freq=w_ngram_freq, c_ngram_freq=c_ngram_freq,
+                                           tokenizer=tokenizer)
             self.config = ClassifierConfig.from_model_config(self._model.config)
 
         self.hash = self._load_hash(model_path)

--- a/mindmeld/components/nlp.py
+++ b/mindmeld/components/nlp.py
@@ -553,8 +553,12 @@ class NaturalLanguageProcessor(Processor):
             intent (str): The gold value for intent classification.
             dynamic_resource (dict, optional): A dynamic resource to aid NLP inference.
         """
-        query_factory = QueryFactory.create_query_factory()
-        _, query, _ = process_markup(markup, query_factory, query_options={})
+        if self.resource_loader:
+            _, query, _ = process_markup(
+                markup, self.resource_loader.query_factory, query_options={})
+        else:
+            query_factory = QueryFactory.create_query_factory()
+            _, query, _ = process_markup(markup, query_factory, query_options={})
 
         if domain:
             print('Inspecting domain classification')

--- a/mindmeld/components/role_classifier.py
+++ b/mindmeld/components/role_classifier.py
@@ -84,6 +84,7 @@ class RoleClassifier(Classifier):
                     self.domain, self.intent, self.entity_type)
 
         # create model with given params
+        kwargs['tokenizer'] = self._resource_loader.query_factory.tokenizer
         model_config = self._get_model_config(**kwargs)
         model = create_model(model_config)
 
@@ -164,6 +165,7 @@ class RoleClassifier(Classifier):
 
             gazetteers = self._resource_loader.get_gazetteers()
             self._model.register_resources(gazetteers=gazetteers)
+            self._model.config.tokenizer = self._resource_loader.query_factory.tokenizer
             self.config = ClassifierConfig.from_model_config(self._model.config)
 
         self.hash = self._load_hash(model_path)

--- a/mindmeld/components/role_classifier.py
+++ b/mindmeld/components/role_classifier.py
@@ -84,7 +84,6 @@ class RoleClassifier(Classifier):
                     self.domain, self.intent, self.entity_type)
 
         # create model with given params
-        kwargs['tokenizer'] = self._resource_loader.query_factory.tokenizer
         model_config = self._get_model_config(**kwargs)
         model = create_model(model_config)
 
@@ -164,8 +163,8 @@ class RoleClassifier(Classifier):
                 self._model.config.resolve_config(self._get_model_config())
 
             gazetteers = self._resource_loader.get_gazetteers()
-            self._model.register_resources(gazetteers=gazetteers)
-            self._model.config.tokenizer = self._resource_loader.query_factory.tokenizer
+            tokenizer = self._resource_loader.get_tokenizer()
+            self._model.register_resources(gazetteers=gazetteers, tokenizer=tokenizer)
             self.config = ClassifierConfig.from_model_config(self._model.config)
 
         self.hash = self._load_hash(model_path)
@@ -190,7 +189,8 @@ class RoleClassifier(Classifier):
         if not isinstance(query, Query):
             query = self._resource_loader.query_factory.create_query(query)
         gazetteers = self._resource_loader.get_gazetteers()
-        self._model.register_resources(gazetteers=gazetteers)
+        tokenizer = self._resource_loader.get_tokenizer()
+        self._model.register_resources(gazetteers=gazetteers, tokenizer=tokenizer)
         return self._model.predict([(query, entities, entity_index)])[0]
 
     def predict_proba(self, query, entities, entity_index):  # pylint: disable=arguments-differ
@@ -211,7 +211,8 @@ class RoleClassifier(Classifier):
         if not isinstance(query, Query):
             query = self._resource_loader.query_factory.create_query(query)
         gazetteers = self._resource_loader.get_gazetteers()
-        self._model.register_resources(gazetteers=gazetteers)
+        tokenizer = self._resource_loader.get_tokenizer()
+        self._model.register_resources(gazetteers=gazetteers, tokenizer=tokenizer)
 
         predict_proba_result = self._model.predict_proba([(query, entities, entity_index)])
         class_proba_tuples = list(predict_proba_result[0][1].items())
@@ -236,7 +237,8 @@ class RoleClassifier(Classifier):
         if not isinstance(query, Query):
             query = self._resource_loader.query_factory.create_query(query)
         gazetteers = self._resource_loader.get_gazetteers()
-        self._model.register_resources(gazetteers=gazetteers)
+        tokenizer = self._resource_loader.get_tokenizer()
+        self._model.register_resources(gazetteers=gazetteers, tokenizer=tokenizer)
         return self._model._extract_features((query, entities, entity_index))
 
     def _get_query_tree(self, queries=None, label_set=DEFAULT_TRAIN_SET_REGEX, raw=False):

--- a/mindmeld/models/model.py
+++ b/mindmeld/models/model.py
@@ -716,7 +716,7 @@ class Model:
     def tokenizer(self):
         tokenizer = self._resources.get('tokenizer')
         if not tokenizer:
-            logger.error('The tokenizer resource has not been register '
+            logger.error('The tokenizer resource has not been registered '
                          'to the model. Using default tokenizer.')
             tokenizer = Tokenizer()
         return tokenizer

--- a/mindmeld/models/tagger_models.py
+++ b/mindmeld/models/tagger_models.py
@@ -165,13 +165,12 @@ class TaggerModel(Model):
         Args:
             query (mindmeld.core.Query): The query to extract features from
             dynamic_resource (dict): The dynamic resource used along with the query
-            tokenizer (Tokenizer): The component used to normalize entities in dynamic_resource
 
         Returns:
             list: A list of dictionaries of extracted features and their weights
         """
         workspace_resource = ingest_dynamic_gazetteer(
-            self._resources, dynamic_resource=dynamic_resource, tokenizer=self.config.tokenizer)
+            self._resources, dynamic_resource=dynamic_resource, tokenizer=self.tokenizer)
         return self._clf.extract_example_features(query, self.config, workspace_resource)
 
     def _fit(self, examples, labels, params=None):
@@ -211,7 +210,7 @@ class TaggerModel(Model):
             return [()]
 
         workspace_resource = ingest_dynamic_gazetteer(
-            self._resources, dynamic_resource=dynamic_resource, tokenizer=self.config.tokenizer)
+            self._resources, dynamic_resource=dynamic_resource, tokenizer=self.tokenizer)
         predicted_tags = self._clf.extract_and_predict(examples, self.config,
                                                        workspace_resource)
         # Decode the tags to labels
@@ -233,7 +232,7 @@ class TaggerModel(Model):
             return []
 
         workspace_resource = ingest_dynamic_gazetteer(
-            self._resources, dynamic_resource=dynamic_resource, tokenizer=self.config.tokenizer)
+            self._resources, dynamic_resource=dynamic_resource, tokenizer=self.tokenizer)
         predicted_tags_probas = self._clf.predict_proba(examples, self.config,
                                                         workspace_resource)
         tags, probas = zip(*predicted_tags_probas[0])

--- a/mindmeld/models/tagger_models.py
+++ b/mindmeld/models/tagger_models.py
@@ -24,7 +24,6 @@ from .taggers.crf import ConditionalRandomFields
 from .taggers.memm import MemmModel
 from .taggers.lstm import LstmModel
 from ..exceptions import MindMeldError
-from ..tokenizer import Tokenizer
 
 logger = logging.getLogger(__name__)
 
@@ -166,13 +165,13 @@ class TaggerModel(Model):
         Args:
             query (mindmeld.core.Query): The query to extract features from
             dynamic_resource (dict): The dynamic resource used along with the query
+            tokenizer (Tokenizer): The component used to normalize entities in dynamic_resource
 
         Returns:
             list: A list of dictionaries of extracted features and their weights
         """
-        tokenizer = Tokenizer()
         workspace_resource = ingest_dynamic_gazetteer(
-            self._resources, dynamic_resource=dynamic_resource, tokenizer=tokenizer)
+            self._resources, dynamic_resource=dynamic_resource, tokenizer=self.config.tokenizer)
         return self._clf.extract_example_features(query, self.config, workspace_resource)
 
     def _fit(self, examples, labels, params=None):
@@ -211,9 +210,8 @@ class TaggerModel(Model):
         if self._no_entities:
             return [()]
 
-        tokenizer = Tokenizer()
         workspace_resource = ingest_dynamic_gazetteer(
-            self._resources, dynamic_resource=dynamic_resource, tokenizer=tokenizer)
+            self._resources, dynamic_resource=dynamic_resource, tokenizer=self.config.tokenizer)
         predicted_tags = self._clf.extract_and_predict(examples, self.config,
                                                        workspace_resource)
         # Decode the tags to labels
@@ -234,9 +232,8 @@ class TaggerModel(Model):
         if self._no_entities:
             return []
 
-        tokenizer = Tokenizer()
         workspace_resource = ingest_dynamic_gazetteer(
-            self._resources, dynamic_resource=dynamic_resource, tokenizer=tokenizer)
+            self._resources, dynamic_resource=dynamic_resource, tokenizer=self.config.tokenizer)
         predicted_tags_probas = self._clf.predict_proba(examples, self.config,
                                                         workspace_resource)
         tags, probas = zip(*predicted_tags_probas[0])

--- a/mindmeld/models/text_models.py
+++ b/mindmeld/models/text_models.py
@@ -32,7 +32,6 @@ from sklearn.tree import DecisionTreeClassifier
 from .helpers import (QUERY_FREQ_RSC, WORD_FREQ_RSC, WORD_NGRAM_FREQ_RSC,
                       CHAR_NGRAM_FREQ_RSC, register_model)
 from .model import EvaluatedExample, Model, StandardModelEvaluation
-from ..tokenizer import Tokenizer
 
 _NEG_INF = -1e10
 
@@ -208,9 +207,8 @@ class TextModel(Model):
         return predictions
 
     def view_extracted_features(self, example, dynamic_resource=None):
-        tokenizer = Tokenizer()
         return self._extract_features(
-            example, dynamic_resource=dynamic_resource, tokenizer=tokenizer)
+            example, dynamic_resource=dynamic_resource, tokenizer=self.config.tokenizer)
 
     def _get_feature_weight(self, feat_name, label_class):
         """ Retrieves the feature weight from the coefficient matrix. If there are only two
@@ -257,9 +255,8 @@ class TextModel(Model):
 
         pred_label = self.predict([example], dynamic_resource=dynamic_resource)[0]
         pred_class = self._class_encoder.transform([pred_label])
-        tokenizer = Tokenizer()
         features = self._extract_features(
-            example, dynamic_resource=dynamic_resource, tokenizer=tokenizer)
+            example, dynamic_resource=dynamic_resource, tokenizer=self.config.tokenizer)
 
         logging.info("Predicted: %s.", pred_label)
 
@@ -333,9 +330,8 @@ class TextModel(Model):
         """
         groups = []
         feats = []
-        tokenizer = Tokenizer()
         for idx, example in enumerate(examples):
-            feats.append(self._extract_features(example, dynamic_resource, tokenizer))
+            feats.append(self._extract_features(example, dynamic_resource, self.config.tokenizer))
             groups.append(idx)
 
         X, y = self._preprocess_data(feats, y, fit=fit)

--- a/mindmeld/models/text_models.py
+++ b/mindmeld/models/text_models.py
@@ -208,7 +208,7 @@ class TextModel(Model):
 
     def view_extracted_features(self, example, dynamic_resource=None):
         return self._extract_features(
-            example, dynamic_resource=dynamic_resource, tokenizer=self.config.tokenizer)
+            example, dynamic_resource=dynamic_resource, tokenizer=self.tokenizer)
 
     def _get_feature_weight(self, feat_name, label_class):
         """ Retrieves the feature weight from the coefficient matrix. If there are only two
@@ -256,7 +256,7 @@ class TextModel(Model):
         pred_label = self.predict([example], dynamic_resource=dynamic_resource)[0]
         pred_class = self._class_encoder.transform([pred_label])
         features = self._extract_features(
-            example, dynamic_resource=dynamic_resource, tokenizer=self.config.tokenizer)
+            example, dynamic_resource=dynamic_resource, tokenizer=self.tokenizer)
 
         logging.info("Predicted: %s.", pred_label)
 
@@ -331,7 +331,7 @@ class TextModel(Model):
         groups = []
         feats = []
         for idx, example in enumerate(examples):
-            feats.append(self._extract_features(example, dynamic_resource, self.config.tokenizer))
+            feats.append(self._extract_features(example, dynamic_resource, self.tokenizer))
             groups.append(idx)
 
         X, y = self._preprocess_data(feats, y, fit=fit)

--- a/mindmeld/resource_loader.py
+++ b/mindmeld/resource_loader.py
@@ -127,6 +127,14 @@ class ResourceLoader:
 
         return self._entity_files[gaz_name]['gazetteer']['data']
 
+    def get_tokenizer(self):
+        """Get the tokenizer from the query_factory attribute
+
+        Returns:
+            tokenizer (Tokenizer): The resource loaders tokenizer
+        """
+        return self.query_factory.tokenizer
+
     def get_gazetteers_hash(self):
         """
         Gets a single hash of all the gazetteer ordered by alphabetical entity type.

--- a/source/integrations/converters.rst
+++ b/source/integrations/converters.rst
@@ -5,12 +5,12 @@ Introduction
 ------------
 
 The MindMeld conversion tool is designed to help make the migration from other conversational AI platforms to MindMeld seamless.
-Currently, we offer support conversions for Rasa and Dialogflow projects.
+Currently, we offer conversions for Rasa and Dialogflow projects.
 
 How does this tool work?
 ------------------------
 
-This tool will generate a basic scaffold for a MindMeld project from a given Rasa/DialogFlow project, and will use the
+This tool will generate a basic scaffold for a MindMeld project from a given Rasa/Dialogflow project, and will use the
 entities and intents of the existing project to populate the entities folders and create training files in MindMeld.
 Dialogue state handlers will be created for each intent to handle any necessary logic behind responses, and a default model
 configurations file will also be created, which may be changed as needed. If you are unfamiliar with the structure of
@@ -26,7 +26,7 @@ For Rasa project conversion, use the following command:
     mindmeld convert --rs from_rasa_project_location to_mindmeld_project_location
 
 
-For DialogFlow project conversion, use the following command:
+For Dialogflow project conversion, use the following command:
 
 .. code:: console
 

--- a/source/userguide/kb.rst
+++ b/source/userguide/kb.rst
@@ -716,7 +716,7 @@ In the example below, we search for restaurants whose names best match ``firetra
    We can set the ``size`` parameter of the :meth:`execute()` method to specify the maximum number of records.
 
 
-.. _unstructed_data:
+.. _unstructured_data:
 
 Dealing with unstructured text
 ------------------------------

--- a/source/userguide/nlp.rst
+++ b/source/userguide/nlp.rst
@@ -593,7 +593,7 @@ Use the :data:`timestamp` parameter in conjunction with the :data:`time_zone` pa
 Specifying language or locale
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For non-english language applications, it is important to pass in the language or locale code to MindMeld's ``process`` API so that it can interpret the system entities correctly. Locale codes representing the ISO 639-1 language code
+For non-English language applications, it is important to pass in the language or locale code to MindMeld's ``process`` API so that it can interpret the system entities correctly. Locale codes representing the ISO 639-1 language code
 and ISO3166 alpha 2 country code separated by an underscore character, for example, `en_US` and ISO 639-2 language codes, for example, `EN` are used here. We provide a code snippet of how to use this functionality below, assuming you have
 Spanish training data for such queries:
 

--- a/source/userguide/nlp.rst
+++ b/source/userguide/nlp.rst
@@ -616,14 +616,14 @@ Spanish training data for such queries:
 
 .. note::
 
-   If you are using Duckling for system entity resolution (the default), the following non-english languages are only supported: `ducking languages <https://github.com/facebook/duckling/blob/master/Duckling/Locale.hs>`_
+   If you are using Duckling for system entity resolution (the default), only the following languages are supported: `Duckling languages <https://github.com/facebook/duckling/blob/master/Duckling/Locale.hs>`_
 
 .. _stemming:
 
 Language stemming
 ^^^^^^^^^^^^^^^^^
 
-Stemming is an important, language-dependent NLP processing that transforms a word to it's root word. MindMeld allows you to specify their own custom stemmers,
+Stemming is an important, language-dependent NLP process that transforms a word to an approximation of its root form. MindMeld allows you to specify your own custom stemmers,
 which are useful for many languages. We also provide two built-in stemmers that are wrappers around certain NLTK stemming operations -- an English stemmer,
 ``mindmeld.stemmers.EnglishhNLTKStemmer`` and a Spanish stemmer, ``mindmeld.stemmers.SpanishNLTKStemmer``. Below, we provide a code snippet on how to use the
 Spanish built-in stemmer with the NaturalLanguageProcessor object.

--- a/source/userguide/nlp.rst
+++ b/source/userguide/nlp.rst
@@ -588,6 +588,92 @@ Next, we demonstrate the use of the :data:`timestamp` parameter to reproduce how
 
 Use the :data:`timestamp` parameter in conjunction with the :data:`time_zone` parameter to ensure consistent responses when writing tests and inspecting how the NLP would respond at specific points of time.
 
+.. _specify_language:
+
+Specifying language or locale
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For non-english language applications, it is important to pass in the language or locale code to MindMeld's ``process`` API so that it can interpret the system entities correctly. Locale codes representing the ISO 639-1 language code
+and ISO3166 alpha 2 country code separated by an underscore character, for example, `en_US` and ISO 639-2 language codes, for example, `EN` are used here. We provide a code snippet of how to use this functionality below, assuming you have
+spanish training data for such queries:
+
+.. code:: python
+
+    nlp.process('despiértame a las 8', language='ES')
+
+.. code-block:: console
+
+       { 'domain': 'times_and_dates',
+         'entities': [ { 'role': None,
+                         'span': {'end': 19, 'start': 18},
+                         'text': '8',
+                         'type': 'sys_time',
+                         'value': [ { 'grain': 'hour',
+                                      'value': '2019-02-16T08:00:00.000-08:00'}]}],
+         'intent': 'set_alarm',
+         'text': 'despiértame a las 8'
+       }
+
+.. note::
+
+   If you are using Duckling for system entity resolution (the default), the following non-english languages are only supported: `ducking languages <https://github.com/facebook/duckling/blob/master/Duckling/Locale.hs>`_
+
+.. _stemming:
+
+Language stemming
+^^^^^^^^^^^^^^^^^
+
+Stemming is an important, language-dependent NLP processing that transforms a word to it's root word. MindMeld allows you to specify their own custom stemmers,
+which are useful for non-english languages. We also provide two in-built stemmers that are wrappers around certain NLTK stemming operations, an English stemmer,
+``mindmeld.stemmers.EnglishhNLTKStemmer`` and a Spanish stemmer, ``mindmeld.stemmers.SpanishNLTKStemmer``. Below, we provide a code snippet on how to use the
+Spanish built-in stemmer with the NaturalLanguageProcessor object.
+
+
+.. code-block:: python
+
+   from mindmeld.query_factory import QueryFactory
+   from mindmeld.stemmers import SpanishNLTKStemmer
+   from mindmeld.resource_loader import ResourceLoader
+   from mindmeld.components.nlp import NaturalLanguageProcessor
+
+   app_path = "<spanish-mindmeld-application>"
+
+   query_factory = QueryFactory.create_query_factory(app_path, stemmer=SpanishNLTKStemmer())
+   resource_loader = ResourceLoader.create_resource_loader(app_path, query_factory=query_factory)
+
+   nlp = NaturalLanguageProcessor(app_path, resource_loader)
+   nlp.load()
+   nlp.domain_classifier.view_extracted_features('habilite los altavoces')
+
+.. code-block:: console
+   :emphasize-lines: 2,6
+
+   {'bag_of_words|length:1|ngram:habilite': 1,
+    'bag_of_words_stemmed|length:1|ngram:habilit': 1,
+    'bag_of_words|length:1|ngram:los': 1,
+    'bag_of_words_stemmed|length:1|ngram:los': 1,
+    'bag_of_words|length:1|ngram:altavoces': 1,
+    'bag_of_words_stemmed|length:1|ngram:altavoc': 1,
+    'bag_of_words|length:2|ngram:habilite los': 1,
+    'bag_of_words_stemmed|length:2|ngram:habilit los': 1,
+    'bag_of_words|length:2|ngram:los altavoces': 1,
+    'bag_of_words_stemmed|length:2|ngram:los altavoc': 1,
+    'bag_of_words|edge:left|length:1|ngram:OOV': 1,
+    'bag_of_words|edge:right|length:1|ngram:altavoces': 1,
+    'bag_of_words|edge:left|length:2|ngram:OOV los': 1,
+    'bag_of_words|edge:right|length:2|ngram:los altavoces': 1,
+    'exact|query:<OOV>': 10,
+    'in_vocab:OOV': 0.3333333333333333,
+    'in_vocab:IV|freq_bin:3': 0.5283208335737187,
+    'bag_of_words|length:1|word_shape:xxxxx+': 0.5283208335737187,
+    'bag_of_words|length:1|word_shape:xxx': 0.3333333333333333,
+    'bag_of_words|length:2|word_shape:xxxxx+ xxx': 0.3333333333333333,
+    'bag_of_words|length:2|word_shape:xxx xxxxx+': 0.3333333333333333}
+
+In the above query, we see the features extracted included `habilit`, the stemmed version of the word `habilite` and `altavoc`,
+the stemmed version of the word `altavoces`.
+
+
 .. _evaluate_nlp:
 
 Evaluate NLP performance

--- a/source/userguide/nlp.rst
+++ b/source/userguide/nlp.rst
@@ -624,7 +624,7 @@ Language stemming
 ^^^^^^^^^^^^^^^^^
 
 Stemming is an important, language-dependent NLP processing that transforms a word to it's root word. MindMeld allows you to specify their own custom stemmers,
-which are useful for non-english languages. We also provide two in-built stemmers that are wrappers around certain NLTK stemming operations, an English stemmer,
+which are useful for many languages. We also provide two built-in stemmers that are wrappers around certain NLTK stemming operations -- an English stemmer,
 ``mindmeld.stemmers.EnglishhNLTKStemmer`` and a Spanish stemmer, ``mindmeld.stemmers.SpanishNLTKStemmer``. Below, we provide a code snippet on how to use the
 Spanish built-in stemmer with the NaturalLanguageProcessor object.
 

--- a/source/userguide/nlp.rst
+++ b/source/userguide/nlp.rst
@@ -595,7 +595,7 @@ Specifying language or locale
 
 For non-english language applications, it is important to pass in the language or locale code to MindMeld's ``process`` API so that it can interpret the system entities correctly. Locale codes representing the ISO 639-1 language code
 and ISO3166 alpha 2 country code separated by an underscore character, for example, `en_US` and ISO 639-2 language codes, for example, `EN` are used here. We provide a code snippet of how to use this functionality below, assuming you have
-spanish training data for such queries:
+Spanish training data for such queries:
 
 .. code:: python
 

--- a/source/versions/changes.rst
+++ b/source/versions/changes.rst
@@ -43,7 +43,7 @@ MindMeld 4.2 now supports non-english system entity classification and resolutio
 
 **7. Stemming**
 
-MindMeld 4.2 allows developers to specify their own custom stemmers, which are useful for non-english languages. Please see :ref:`Stemming <stemming>` for more details.
+MindMeld 4.2 allows developers to specify their own custom stemmers, which are useful for many languages. Please see :ref:`Stemming <stemming>` for more details.
 
 **8. DialogueFlow.reprocess**
 

--- a/source/versions/changes.rst
+++ b/source/versions/changes.rst
@@ -39,7 +39,7 @@ to Webex Teams. See :doc:`Webex bot integration <../integrations/webex_teams>` f
 
 **6. Locale and Language codes**
 
-MindMeld 4.2 now supports non-english system entity classification and resolution. Please see :ref:`Specify language and locale codes <specify_language>` for more details.
+MindMeld 4.2 now supports system entity classification and resolution in non-English languages. Please see :ref:`Specify language and locale codes <specify_language>` for more details.
 
 **7. Stemming**
 

--- a/source/versions/changes.rst
+++ b/source/versions/changes.rst
@@ -6,7 +6,7 @@ MindMeld 4.2
 -------------
 
 
-MindMeld 4.2 packages several new features to allow developers to build non-english NLP applications, do unstructured QA searches,
+MindMeld 4.2 packages several new features to make it easier for developers to build NLP applications for non-English languages, do unstructured QA searches,
 and convert Rasa and Dialogflow conversation applications to MindMeld applications for ease of on-boarding onto the platform.
 
 **1. MindMeld UI**

--- a/source/versions/changes.rst
+++ b/source/versions/changes.rst
@@ -7,7 +7,7 @@ MindMeld 4.2
 
 
 MindMeld 4.2 packages several new features to allow developers to build non-english NLP applications, do unstructured QA searches,
-and convert RASA and DialogFlow conversation applications to MindMeld applications for ease of on-boarding onto the platform.
+and convert Rasa and Dialogflow conversation applications to MindMeld applications for ease of on-boarding onto the platform.
 
 **1. MindMeld UI**
 

--- a/source/versions/changes.rst
+++ b/source/versions/changes.rst
@@ -30,7 +30,7 @@ MindMeld 4.2 includes built-in support to automatically convert Rasa and Dialogf
 **4. New Human Resources Blueprint**
 
 MindMeld 4.2 provide an enterprise Human Resources bot blueprint to complement the existing consumer blueprints we currently support. Refer to
-:ref:`hr assistant <hr_assistant>` blueprint for more details.
+:ref:`HR assistant <hr_assistant>` blueprint for more details.
 
 **5. Webex Teams Bot Integration**
 

--- a/source/versions/changes.rst
+++ b/source/versions/changes.rst
@@ -5,8 +5,9 @@ Recent Changes
 MindMeld 4.2
 -------------
 
-MindMeld 4.2 packages several new features to allow developers to build non-english NLP applications, do unstructured Q/A searches,
- and convert RASA and DialogFlow conversation applications to MindMeld applications for ease of on-boarding onto the platform.
+
+MindMeld 4.2 packages several new features to allow developers to build non-english NLP applications, do unstructured QA searches,
+and convert RASA and DialogFlow conversation applications to MindMeld applications for ease of on-boarding onto the platform.
 
 **1. MindMeld UI**
 
@@ -19,7 +20,7 @@ serves as a debugging tool to step through the various stages of query processin
 MindMeld 4.2 includes a built-in Question-Answering (QA) component using Elasticsearch for unstructured text retrieval.
 This new feature can be used to perform QA using a knowledge base of passages, frequently asked questions or any long-form
 text data. This complements the structured text retrieval already supported in MindMeld for knowledge-base search. See
-:ref:`dealing with unstructed data <unstructed_data>` for more details.
+:ref:`dealing with unstructed data <unstructured_data>` for more details.
 
 **3. MindMeld converter for Rasa and Dialogflow**
 
@@ -29,7 +30,7 @@ MindMeld 4.2 includes built-in support to automatically convert Rasa and Dialogf
 **4. New Human Resources Blueprint**
 
 MindMeld 4.2 provide an enterprise Human Resources bot blueprint to complement the existing consumer blueprints we currently support. Refer to
- :ref:`hr assistant <hr_assistant>` blueprint for more details.
+:ref:`hr assistant <hr_assistant>` blueprint for more details.
 
 **5. Webex Teams Bot Integration**
 
@@ -38,51 +39,16 @@ to Webex Teams. See :doc:`Webex bot integration <../integrations/webex_teams>` f
 
 **6. Locale and Language codes**
 
-Locale codes representing the ISO 639-1 language code and ISO3166 alpha 2 country code separated by an underscore
-character, for example, `en_US` and ISO 639-2 language codes, for example, `EN`, can now be used in MindMeld 4.2 to
-perform NLP tasks on non-english languages.
-
-Previously, the system entity recognizer, which is rule-based and not trained on app-specific data, could not
-extract system_entities like the time entity ``8`` in the spanish query ``despiértame a las 8``. By passing in the locale
-or language code, MindMeld will infer the correct time entity in the above query. We provide a code snippet of how
-to use this functionality below, assuming you have spanish training data for such queries:
-
-.. code:: python
-
-    nlp.process('despiértame a las 8', language='ES')
-
-.. code-block:: console
-
-       { 'domain': 'times_and_dates',
-         'entities': [ { 'role': None,
-                         'span': {'end': 19, 'start': 18},
-                         'text': '8',
-                         'type': 'sys_time',
-                         'value': [ { 'grain': 'hour',
-                                      'value': '2019-02-16T08:00:00.000-08:00'}]}],
-         'intent': 'set_alarm',
-         'text': 'despiértame a las 8'
-       }
-
+MindMeld 4.2 now supports non-english system entity classification and resolution. Please see :ref:`Specify language and locale codes <specify_language>` for more details.
 
 **7. Stemming**
 
-MindMeld 4.2 allows developers to specify their own custom stemmers, which are useful for non-english languages. We also provide
-two in-built stemmers that are wrappers around certain NLTK stemming operations, an English stemmer,
-``mindmeld.stemmers.EnglishhNLTKStemmer`` and a Spanish stemmer, ``mindmeld.stemmers.SpanishNLTKStemmer``. Below, we provide a code
-snippet on how to use the Spanish built-in stemmer with the NaturalLanguageProcessor object.
+MindMeld 4.2 allows developers to specify their own custom stemmers, which are useful for non-english languages. Please see :ref:`Stemming <stemming>` for more details.
 
-.. code:: python
-
-        query_factory = QueryFactory.create_query_factory(app_path, stemmer=SpanishNLTKStemmer())
-        resource_loader = ResourceLoader.create_resource_loader(app_path, query_factory=query_factory)
-        nlp = NaturalLanguageProcessor(app_path, resource_loader)
-
-
-**8. Dialogflow.reprocess**
+**8. DialogueFlow.reprocess**
 
 MindMeld 4.2 includes an improvement to DialogueFlow (a MindMeld dialogue feature) where the user can exit the current dialogue flow and
-return to a default flow. Refer to :ref:`Existing Dialogue Flow <exiting_dialogue_flow>` section on how to exit an existing dialogue flow.
+return to a default flow. Refer to :ref:`Exiting Dialogue Flow <exiting_dialogue_flow>` section on how to exit an active dialogue flow.
 
 **9. Docker updates**
 

--- a/source/versions/history.rst
+++ b/source/versions/history.rst
@@ -1,7 +1,7 @@
 Package History
 ===============
 
-4.2.0 (2019-09-01)
+4.2.0 (2019-09-16)
 ------------------
 
 Major Features and Improvements
@@ -9,7 +9,7 @@ Major Features and Improvements
 
 - MindMeld UI is a sample web-based chat client interface to interact with any MindMeld application
 
-- A built-in Question-Answering (QA) component for un-structured data using Elasticsearch
+- A built-in Question-Answering (QA) component for unstructured data using Elasticsearch
 
 - Converters for Rasa and Dialogflow projects into MindMeld projects
 


### PR DESCRIPTION
This PR does the following:
1. Consolidates the tokenization logic such that the models and classifiers only access the tokenizer passed in from the resource loader instead of instantiating one. This prevent any tokenization discrepancies that arise if the developer provides a non-default tokenizer (for example, for non-english languages).
2. Adds sections on stemming and language code instead of stating it in the recent changes section