### PR TITLE
Adding explicit error handling in reading query files

### DIFF
--- a/mindmeld/markup.py
+++ b/mindmeld/markup.py
@@ -134,7 +134,7 @@ def read_query_file(file_path):
                 if query_text:
                     yield query_text
     except IOError:
-        logger.error('Problem reading file {0}.'.format(file_path))
+        logger.error('Problem reading file %s.', file_path)
         yield from ()
 
 

--- a/mindmeld/markup.py
+++ b/mindmeld/markup.py
@@ -14,6 +14,7 @@
 """The markup module contains functions for interacting with the MindMeld Markup language for
 representing annotations of query text inline.
 """
+import codecs
 import logging
 
 from .core import Entity, NestedEntity, ProcessedQuery, QueryEntity, Span
@@ -124,14 +125,17 @@ def read_query_file(file_path):
     Yields:
         str: query text for each line
     """
-    import codecs
-    with codecs.open(file_path, encoding='utf-8') as queries_file:
-        for line in queries_file:
-            line = line.strip()
-            # only create query if line is not empty string
-            query_text = line.split('\t')[0].strip()
-            if query_text:
-                yield query_text
+    try:
+        with codecs.open(file_path, encoding='utf-8') as queries_file:
+            for line in queries_file:
+                line = line.strip()
+                # only create query if line is not empty string
+                query_text = line.split('\t')[0].strip()
+                if query_text:
+                    yield query_text
+    except IOError:
+        logger.error('Problem reading file {0}.'.format(file_path))
+        yield from ()
 
 
 def bootstrap_query_file(input_file, output_file, nlp, **kwargs):


### PR DESCRIPTION
If there is an issue reading a query file, handle it gracefully, log the error and yield an empty list