### PR TITLE
Make markup error messages more useful

### DIFF
--- a/mindmeld/markup.py
+++ b/mindmeld/markup.py
@@ -408,11 +408,14 @@ def _tokenize_markup(markup):
                 else:
                     key = 'entity'
                 if open_annotations[key] == 0:
-                    raise MarkupError('Mismatched end for {} at position {}'.format(key, idx))
+                    msg = 'Mismatched end for {} at position {}: {}'.format(key, idx, markup)
+                    raise MarkupError(msg)
                 if not token_is_meta:
-                    raise MarkupError('Missing label for {} at position {}'.format(key, idx))
+                    msg = 'Missing label for {} at position {}: {}'.format(key, idx, markup)
+                    raise MarkupError(msg)
                 if not token:
-                    raise MarkupError('Empty label for {} at position {}'.format(key, idx))
+                    msg = 'Empty label for {} at position {}: {}'.format(key, idx, markup)
+                    raise MarkupError(msg)
                 open_annotations[key] -= 1
 
                 yield token
@@ -426,7 +429,7 @@ def _tokenize_markup(markup):
 
     for key in open_annotations:
         if open_annotations[key]:
-            raise MarkupError('Mismatched start for {}'.format(key))
+            raise MarkupError('Mismatched start for {}: {}'.format(key, markup))
 
     if token:
         yield token

--- a/mindmeld/models/taggers/taggers.py
+++ b/mindmeld/models/taggers/taggers.py
@@ -21,6 +21,7 @@ from ...core import QueryEntity, Span, TEXT_FORM_RAW, \
     TEXT_FORM_NORMALIZED, _sort_by_lowest_time_grain
 from ...ser import resolve_system_entity, SystemEntityResolutionError
 from ..helpers import get_feature_extractor, ENABLE_STEMMING
+from ...markup import MarkupError
 
 logger = logging.getLogger(__name__)
 
@@ -222,8 +223,7 @@ def get_tags_from_entities(query, entities, scheme='IOB'):
     try:
         iobs, types = _get_tags_from_entities(query, entities, scheme)
     except IndexError:
-        logger.error("Invalid entities %s in '%s'", entities, query)
-        raise
+        raise MarkupError("Invalid entities {} in '{}'".format(entities, query))
     tags = ['|'.join(args) for args in zip(iobs, types)]
     return tags
 

--- a/mindmeld/models/taggers/taggers.py
+++ b/mindmeld/models/taggers/taggers.py
@@ -222,7 +222,7 @@ def get_tags_from_entities(query, entities, scheme='IOB'):
     try:
         iobs, types = _get_tags_from_entities(query, entities, scheme)
     except IndexError:
-        logger.error("Invalid entities {} in '{}'".format(entities, query))
+        logger.error("Invalid entities %s in '%s'", entities, query)
         raise
     tags = ['|'.join(args) for args in zip(iobs, types)]
     return tags

--- a/mindmeld/models/taggers/taggers.py
+++ b/mindmeld/models/taggers/taggers.py
@@ -219,7 +219,11 @@ def get_tags_from_entities(query, entities, scheme='IOB'):
             '' if the IOB status is 'O'. The last two are like the first two, \
             but for system entities.
     """
-    iobs, types = _get_tags_from_entities(query, entities, scheme)
+    try:
+        iobs, types = _get_tags_from_entities(query, entities, scheme)
+    except IndexError:
+        logger.error("Invalid entities {} in '{}'".format(entities, query))
+        raise
     tags = ['|'.join(args) for args in zip(iobs, types)]
     return tags
 


### PR DESCRIPTION
When reading in query files with bad markup, from some kinds of badness you can get an error that just says where in the query something bad happens, without enough detail to find the bad query. This adds the query to the message.