### PR TITLE
Relax CalVer dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md") as readme_file:
     readme = readme_file.read()
 
 requirements = [
-    "attrs~=18.2",
+    'attrs>=18.2',  # attrs has a stable API and does not use semver
     "Click~=6.0",
     "click-log==0.1.8",
     "distro~=1.3",
@@ -16,14 +16,14 @@ requirements = [
     "Flask~=0.12",
     "Flask-Cors~=3.0",
     "future~=0.16.0",
-    "pycountry~=19.8",
+    'pycountry',  # uses calendar versioning
     "nltk~=3.2",
     "numpy~=1.15",
     "pandas~=0.22",
     "pip>=9.0.1",
     "py~=1.4",
     "python-dateutil~=2.6",
-    "pytz>=2018.5",
+    'pytz',  # uses calendar versioning
     "scipy>=0.9,<2.0",
     'scikit-learn>=0.18.1,<0.20; python_version < "3.7"',
     'scikit-learn>=0.19.2,<0.20; python_version >= "3.7"',


### PR DESCRIPTION
Three dependencies use [calendar versioning](https://calver.org/) instead of [semantic versioning](https://semver.org/):
- [attrs](http://www.attrs.org/en/stable/)
- [pycountry](https://github.com/flyingcircusio/pycountry)
- [pytz](http://pytz.sourceforge.net/)

This PR updates setup.py to better handle these dependencies