### PR TITLE
Gracefully handle missing tensorflow extra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 python:
   - "3.5"
   - "3.6"
+env:
+   - MM_EXTRAS=true
+   - MM_EXTRAS=false
 jdk:
   - openjdk8
 # command to install services
@@ -10,10 +13,7 @@ services:
   - elasticsearch
 # command to install dependencies
 install:
-  - pip install --upgrade pip
-  - pip install .
-  - pip install "mindmeld[bot]"
-  - pip install -r test-requirements.txt
+  - scripts/travis_install.sh
 before_script:
   - sleep 10
 # command to run tests

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -1,0 +1,2 @@
+-e .[bot]
+-e .[tensorflow]

--- a/lintme
+++ b/lintme
@@ -3,14 +3,20 @@
 EXCLUDE_ASYNC=`python -c "import sys; print('True' if sys.version_info >= (3,5) else '')"`
 BLACK=`python -c "import sys; print('True' if sys.version_info >= (3,6) else '')"`
 
-OPTIONS=""
+FLAKE8_OPTIONS=""
 if [[ -z "$EXCLUDE_ASYNC" ]]; then
-  OPTIONS="--exclude=*_async.py"
+  FLAKE8_OPTIONS="--exclude=*_async.py"
+fi
+
+if [ "$MM_EXTRAS" == "true" ]; then
+  PYLINT_OPTIONS=""
+else
+  PYLINT_OPTIONS="--ignore mindmeld/bot"
 fi
 
 if [[ "$BLACK" ]]; then
   black --check .
 fi
 
-flake8 mindmeld tests $OPTIONS
-pylint mindmeld
+flake8 mindmeld tests $FLAKE8_OPTIONS
+pylint mindmeld $PYLINT_OPTIONS

--- a/mindmeld/bot/__init__.py
+++ b/mindmeld/bot/__init__.py
@@ -12,6 +12,14 @@
 # limitations under the License.
 
 """This module contains the components of the MindMeld platform"""
-from .webex_bot_server import WebexBotServer
+try:
+    from .webex_bot_server import WebexBotServer
 
-__all__ = ["WebexBotServer"]
+    __all__ = ["WebexBotServer"]
+except ImportError:
+    import warnings
+
+    warnings.warn(
+        "Dependency not found. Please install the mindmeld[bot] extra to use mindmeld.bot"
+    )
+    __all__ = []

--- a/mindmeld/bot/__init__.py
+++ b/mindmeld/bot/__init__.py
@@ -15,11 +15,11 @@
 try:
     from .webex_bot_server import WebexBotServer
 
-    __all__ = ["WebexBotServer"]
 except ImportError:
     import warnings
 
     warnings.warn(
         "Dependency not found. Please install the mindmeld[bot] extra to use mindmeld.bot"
     )
-    __all__ = []
+
+__all__ = ["WebexBotServer"]

--- a/mindmeld/bot/webex_bot_server.py
+++ b/mindmeld/bot/webex_bot_server.py
@@ -7,9 +7,9 @@ This module contains the Webex Bot Server component.
 import json
 import logging
 
-import requests
 from ciscosparkapi import CiscoSparkAPI
 from flask import Flask, request
+import requests
 
 from ..components import NaturalLanguageProcessor
 from ..components.dialogue import Conversation

--- a/mindmeld/models/tagger_models.py
+++ b/mindmeld/models/tagger_models.py
@@ -28,8 +28,13 @@ from .helpers import (
 )
 from .model import EntityModelEvaluation, EvaluatedExample, Model, ModelConfig
 from .taggers.crf import ConditionalRandomFields
-from .taggers.lstm import LstmModel
 from .taggers.memm import MemmModel
+
+try:
+    from .taggers.lstm import LstmModel
+except ImportError:
+    LstmModel = None
+
 
 logger = logging.getLogger(__name__)
 
@@ -324,6 +329,12 @@ class TaggerModel(Model):
         """Returns the python class of the actual underlying model"""
         classifier_type = self.config.model_settings["classifier_type"]
         try:
+            if classifier_type == LSTM_TYPE and LstmModel is None:
+                msg = (
+                    "{}: Classifier type {!r} dependencies not found. Install the "
+                    "mindmeld[tensorflow] extra to use this classifier type."
+                )
+                raise ValueError(msg.format(self.__class__.__name__, classifier_type))
             return {
                 MEMM_TYPE: MemmModel,
                 CRF_TYPE: ConditionalRandomFields,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,8 @@
 [pytest]
 filterwarnings =
     ignore::DeprecationWarning
+markers =
+    extras: tests which require extras
+    no_extras: tests which require extras to not be present
+    tensorflow: tests which require the tensorflow extra
+    no_tensorflow: tests which require the tensorflow extra to not be present

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_DIR="$( dirname $SCRIPT_DIR )"
+
+pushd $REPO_DIR
+
+pip install --upgrade pip
+pip install .
+pip install -r test-requirements.txt
+if [ "$MM_EXTRAS" == "true" ]; then
+  pip install -r extras-requirements.txt
+fi
+
+popd

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,4 +9,3 @@ pytest-mock>=1.6.2
 pytest-asyncio>=0.8.0
 pyyaml>=5.1.1
 black>=19.10b0 ; python_version >= '3.6'
-mindmeld[tensorflow]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ Configurations for tests. Include shared fixtures here.
 # pylint: disable=locally-disabled,redefined-outer-name
 import asyncio
 import codecs
+from distutils.util import strtobool
 import os
 import warnings
 
@@ -209,3 +210,20 @@ class FakeApp:
 @pytest.fixture
 def fake_app():
     return FakeApp("123")
+
+
+def pytest_collection_modifyitems(config, items):
+    use_extras = strtobool(os.environ.get("MM_EXTRAS", "false"))
+    skip_markers = ["no_extras"] if use_extras else ["extras"]
+    skip = pytest.mark.skip(
+        reason=(
+            "Skipping tests which require a clean mindmeld install"
+            if use_extras
+            else "Skipping tests which require mindmeld extras"
+        )
+    )
+
+    for item in items:
+        for marker in skip_markers:
+            if marker in item.keywords:
+                item.add_marker(skip)

--- a/tests/models/test_tagging.py
+++ b/tests/models/test_tagging.py
@@ -278,6 +278,42 @@ def test_view_extracted_features(kwik_e_mart_nlp, model_type, params):
     assert extracted_features == expected_features
 
 
+@pytest.mark.no_extras
+@pytest.mark.no_tensorflow
+def test_lstm_er_model_no_tf(kwik_e_mart_nlp):
+    config = {
+        "model_type": "tagger",
+        "model_settings": {
+            "classifier_type": "lstm",
+            "tag_scheme": "IOB",
+            "feature_scaler": "max-abs",
+        },
+        "params": {
+            "number_of_epochs": 3,
+            "token_embedding_dimension": 50,
+            "gaz_encoding_dimension": 50,
+            "token_lstm_hidden_state_dimension": 200,
+        },
+        "features": {
+            "bag-of-words-seq": {"ngram_lengths_to_start_positions": {1: [0],}},
+        },
+    }
+    er = (
+        kwik_e_mart_nlp.domains["store_info"]
+        .intents["get_store_hours"]
+        .entity_recognizer
+    )
+    with pytest.raises(ValueError) as exc_info:
+        er.fit(**config)
+
+    assert exc_info.value.args[0] == (
+        "TaggerModel: Classifier type 'lstm' dependencies not found. "
+        "Install the mindmeld[tensorflow] extra to use this classifier type."
+    )
+
+
+@pytest.mark.extras
+@pytest.mark.tensorflow
 def test_lstm_er_model(kwik_e_mart_nlp):
     config = {
         "model_type": "tagger",


### PR DESCRIPTION
When the tensorflow extra is not installed users will see an error if they try to use the LstmModel which requires tensorflow:
```
TaggerModel: Classifier type 'lstm' dependencies not found. Install the mindmeld[tensorflow] extra to use this classifier type.
```

Also added a test for this.