### PR TITLE
Adding a reference implementation for a MindMeld http client

### DIFF
--- a/mindmeld/components/client.py
+++ b/mindmeld/components/client.py
@@ -21,8 +21,8 @@ class ConversationClient:
         ['The 23 Elm Street Kwik-E-Mart is open from 7:00 to 19:00.']
 
     Attributes:
-        history (list): The history of the conversation. Starts with the most recent message.
-        context (dict): The context of the conversation, containing user context.
+        history (list): The sequence of previous turns in the conversation, starting with the most recent message.
+        context (dict): The user context of the conversation.
         default_params (dict): The default params to use with each turn. These \
             defaults will be overridden by params passed for each turn.
         params (dict): The params returned by the most recent turn.

--- a/mindmeld/components/client.py
+++ b/mindmeld/components/client.py
@@ -9,12 +9,12 @@ mod_logger = logging.getLogger(__name__)
 
 
 class ConversationClient:
-    """The conversation object is a very basic MindMeld client.
+    """The conversation object is a very basic MindMeld http client.
 
     It can be useful for testing out dialogue flows in python.
 
     Example:
-        >>> convo = Conversation(app_path='path/to/my/app')
+        >>> convo = ConversationClient()
         >>> convo.say('Hello')
         ['Hello. I can help you find store hours. How can I help?']
         >>> convo.say('Is the store on elm open?')
@@ -23,11 +23,9 @@ class ConversationClient:
     Attributes:
         history (list): The history of the conversation. Starts with the most recent message.
         context (dict): The context of the conversation, containing user context.
-        default_params (Params): The default params to use with each turn. These \
+        default_params (dict): The default params to use with each turn. These \
             defaults will be overridden by params passed for each turn.
-        params (FrozenParams): The params returned by the most recent turn.
-        force_sync (bool): Force synchronous return for `say()` and `process()` \
-            even when app is in async mode.
+        params (dict): The params returned by the most recent turn.
     """
 
     _logger = mod_logger.getChild("Conversation")
@@ -157,4 +155,4 @@ class ConversationClient:
         """Reset the history, frame and params of the Conversation object."""
         self.history = []
         self.frame = {}
-        self.params = FrozenParams()
+        self.params = {}

--- a/mindmeld/components/client.py
+++ b/mindmeld/components/client.py
@@ -1,0 +1,160 @@
+import copy
+import json
+import logging
+import requests
+
+from .dialogue import DirectiveNames
+
+mod_logger = logging.getLogger(__name__)
+
+
+class ConversationClient:
+    """The conversation object is a very basic MindMeld client.
+
+    It can be useful for testing out dialogue flows in python.
+
+    Example:
+        >>> convo = Conversation(app_path='path/to/my/app')
+        >>> convo.say('Hello')
+        ['Hello. I can help you find store hours. How can I help?']
+        >>> convo.say('Is the store on elm open?')
+        ['The 23 Elm Street Kwik-E-Mart is open from 7:00 to 19:00.']
+
+    Attributes:
+        history (list): The history of the conversation. Starts with the most recent message.
+        context (dict): The context of the conversation, containing user context.
+        default_params (Params): The default params to use with each turn. These \
+            defaults will be overridden by params passed for each turn.
+        params (FrozenParams): The params returned by the most recent turn.
+        force_sync (bool): Force synchronous return for `say()` and `process()` \
+            even when app is in async mode.
+    """
+
+    _logger = mod_logger.getChild("Conversation")
+
+    def __init__(
+        self, url="http://localhost:7150/parse", context=None, default_params=None,
+    ):
+        """
+        Args:
+            url (str): The url to be used to talk to the query endpoint.
+            context (dict, optional): The context to be used in the conversation.
+            default_params (dict, optional): The default params to use with each turn. These
+                defaults will be overridden by params passed for each turn.
+        """
+        self.url = url
+        self.context = context or {}
+        self.history = []
+        self.frame = {}
+        if default_params is None:
+            default_params = {}
+        self.default_params = default_params
+        self.params = {}
+
+    def say(
+        self, text, params=None,
+    ):
+        """Send a message in the conversation. The message will be
+        processed by the app based on the current state of the conversation and
+        returns the extracted messages from the directives.
+
+        Args:
+            text (str): The text of a message.
+            params (dict): The params to use with this message,
+                overriding any defaults which may have been set.
+
+        Returns:
+            (list): A text representation of the dialogue responses.
+        """
+        response = self.process(text, params=params)
+
+        # handle directives
+        response_texts = [self._follow_directive(a) for a in response["directives"]]
+        return response_texts
+
+    def process(self, text, params=None):
+        """Send a message in the conversation. The message will be processed by
+        the app based on the current state of the conversation and returns
+        the response.
+
+        Args:
+            text (str): The text of a message.
+            params (dict): The params to use with this message, overriding any defaults
+                which may have been set.
+
+        Returns:
+            (dict): The dictionary response.
+        """
+        internal_params = copy.deepcopy(self.params)
+
+        if params:
+            for k, v in params.items():
+                internal_params[k] = v
+
+        response = requests.post(
+            url=self.url,
+            json={
+                "text": text,
+                "history": self.history,
+                "context": self.context,
+                "frame": self.frame,
+                "params": internal_params,
+            },
+        ).json()
+
+        self.history = response["history"]
+        self.frame = response["frame"]
+        self.params = response["params"]
+        return response
+
+    def _follow_directive(self, directive):
+        msg = ""
+        try:
+            directive_name = directive["name"]
+            if directive_name in [DirectiveNames.REPLY, DirectiveNames.SPEAK]:
+                msg = directive["payload"]["text"]
+            elif directive_name == DirectiveNames.SUGGESTIONS:
+                suggestions = directive["payload"]
+                if not suggestions:
+                    raise ValueError
+                msg = "Suggestion{}:".format("" if len(suggestions) == 1 else "s")
+                texts = []
+                for idx, suggestion in enumerate(suggestions):
+                    if idx > 0:
+                        msg += ", {!r}"
+                    else:
+                        msg += " {!r}"
+
+                    texts.append(self._generate_suggestion_text(suggestion))
+                msg = msg.format(*texts)
+            elif directive_name in DirectiveNames.LIST:
+                msg = "\n".join(
+                    [
+                        json.dumps(item, indent=4, sort_keys=True)
+                        for item in directive["payload"]
+                    ]
+                )
+            elif directive_name == DirectiveNames.LISTEN:
+                msg = "Listening..."
+            elif directive_name == DirectiveNames.RESET:
+                msg = "Resetting..."
+        except (KeyError, ValueError, AttributeError):
+            msg = "Unsupported response: {!r}".format(directive)
+
+        return msg
+
+    @staticmethod
+    def _generate_suggestion_text(suggestion):
+        pieces = []
+        if "text" in suggestion:
+            pieces.append(suggestion["text"])
+        if suggestion["type"] != "text":
+            pieces.append("({})".format(suggestion["type"]))
+
+        return " ".join(pieces)
+
+    def reset(self):
+        """Reset the history, frame and params of the Conversation object."""
+        self.history = []
+        self.frame = {}
+        self.params = FrozenParams()

--- a/mindmeld/components/client.py
+++ b/mindmeld/components/client.py
@@ -138,6 +138,7 @@ class ConversationClient:
                 msg = "Resetting..."
         except (KeyError, ValueError, AttributeError):
             msg = "Unsupported response: {!r}".format(directive)
+            self._logger.warning(msg)
 
         return msg
 

--- a/mindmeld/components/client.py
+++ b/mindmeld/components/client.py
@@ -28,7 +28,7 @@ class ConversationClient:
         params (dict): The params returned by the most recent turn.
     """
 
-    _logger = mod_logger.getChild("Conversation")
+    _logger = mod_logger.getChild("ConversationClient")
 
     def __init__(
         self, url="http://localhost:7150/parse", context=None, default_params=None,


### PR DESCRIPTION
This client can be used to interactively query a `parse` endpoint

```
(mindmeld) ➜  mindmeld git:(feature/http-client) ✗ ipython

In [1]: from mindmeld.components.client import ConversationClient

In [2]: conv = ConversationClient()

In [3]: conv.say('hi')
Out[3]: ["Hi, I am your HR assistant. Ask me about an individual employee, company's employee demographics or general policy questions. You can say 'Is Mia married?' or 'Average salary of females' or 'When will I get my W2?'"]

In [4]: conv.say('is Mia married?')
Out[4]: ['Mia Brown is Married']