### PR TITLE
Adding frame and context to the Conversational Client

### DIFF
--- a/mindmeld/components/client.py
+++ b/mindmeld/components/client.py
@@ -152,6 +152,7 @@ class ConversationClient:
                 msg = "Listening..."
             elif directive_name == DirectiveNames.RESET:
                 msg = "Resetting..."
+                self.reset()
         except (KeyError, ValueError, AttributeError):
             msg = "Unsupported response: {!r}".format(directive)
             self._logger.warning(msg)


### PR DESCRIPTION
This allows the user to override the frame and context from the previous request and potentially pass in more information. For example, developers can pass in response from Wx Team buttons and cards. 