### PR TITLE
Added fix to _get_feature_weight

### DIFF
--- a/mindmeld/models/text_models.py
+++ b/mindmeld/models/text_models.py
@@ -239,10 +239,10 @@ class TextModel(Model):
             label_class (int): The index of the label
 
         Returns:
-            (float): The feature weight
+            (ndarray float): The ndarray with a single float element
         """
         if len(self._class_encoder.classes_) == 2 and label_class >= 1:
-            return 0
+            return np.array([0.0])
         else:
             return self._clf.coef_[
                 label_class, self._feat_vectorizer.vocabulary_[feat_name]


### PR DESCRIPTION
This PR fixes a bug in the `nlp.inspect` cli where inspecting domains sometimes leads to the following issue:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'float' object has no attribute 'round'
```

The fix here is consistently return an array of float 0.0 if there are only two label classes. 