### PR TITLE
Added attribute to test MindMeldServer object

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,6 +14,7 @@ def app_manager(kwik_e_mart_app_path, kwik_e_mart_nlp):
 @pytest.fixture
 def client(app_manager):
     server = MindMeldServer(app_manager)._server.test_client()
+    server.is_xhr = True
     yield server
 
 


### PR DESCRIPTION
The `is_xhr` attr is being called by the jsonify which currently fails.