### PR TITLE
Added request timeout configuration

### DIFF
--- a/mindmeld/system_entity_recognizer.py
+++ b/mindmeld/system_entity_recognizer.py
@@ -13,15 +13,22 @@
 import json
 import logging
 import sys
-
+import os
 import requests
 
 from mindmeld.components._config import (
     get_system_entity_url_config,
     is_duckling_configured,
 )
+from mindmeld.exceptions import MindMeldError
 
 NO_RESPONSE_CODE = -1
+SYS_ENTITY_REQUEST_TIMEOUT = os.environ.get("MM_SYS_ENTITY_REQUEST_TIMEOUT", 1.0)
+try:
+    if float(SYS_ENTITY_REQUEST_TIMEOUT) <= 0.0:
+        raise MindMeldError("MM_SYS_ENTITY_REQUEST_TIMEOUT env var has to be > 0.0 seconds.")
+except ValueError:
+    raise MindMeldError("MM_SYS_ENTITY_REQUEST_TIMEOUT env var has to be a float value.")
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +90,7 @@ class SystemEntityRecognizer:
         url = get_system_entity_url_config(app_path=self.app_path)
 
         try:
-            response = requests.request("POST", url, data=data, timeout=1)
+            response = requests.request("POST", url, data=data, timeout=SYS_ENTITY_REQUEST_TIMEOUT)
 
             if response.status_code == requests.codes["ok"]:
                 response_json = response.json()

--- a/source/userguide/getting_started.rst
+++ b/source/userguide/getting_started.rst
@@ -481,3 +481,7 @@ Environment Variables
 MM_SUBPROCESS_COUNT
 ^^^^^^^^^^^^^^^^^^^
 MindMeld supports parallel processing via process forking when the input is a list of queries, as is the case when :ref:`leveraging n-best ASR transcripts for entity resolution <nbest_lists>`. Set this variable to an integer value to adjust the number of subprocesses. The default is ``4``. Setting it to ``0`` will turn off the feature.
+
+MM_SYS_ENTITY_REQUEST_TIMEOUT
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+This variable sets the request timeout value for the :ref:`system entity recognition service <configuring-system-entities>` . The default float value is ``1.0 seconds``.


### PR DESCRIPTION
This PR makes the request call to the system entity recognition service to have a configurable timeout. Refer to https://github.com/cisco/mindmeld/issues/119.