### PR TITLE
Remove Language param from process

### DIFF
--- a/mindmeld/components/_config.py
+++ b/mindmeld/components/_config.py
@@ -469,7 +469,6 @@ DEFAULT_NLP_CONFIG = {
 
 
 def get_language_config(app_path):
-
     if not app_path:
         return ENGLISH_LANGUAGE_CODE, ENGLISH_US_LOCALE
     try:

--- a/mindmeld/components/nlp.py
+++ b/mindmeld/components/nlp.py
@@ -392,6 +392,7 @@ class NaturalLanguageProcessor(Processor):
         self.name = app_path
         self._load_custom_features()
         self.domain_classifier = DomainClassifier(self.resource_loader)
+        self.app_language, self.app_locale = get_language_config(app_path)
 
         for domain in path.get_domains(self._app_path):
             self._children[domain] = DomainProcessor(
@@ -692,7 +693,7 @@ class NaturalLanguageProcessor(Processor):
             allowed_nlp_classes = self.extract_allowed_intents(allowed_intents)
 
         if not language and not locale:
-            language, locale = get_language_config(self._app_path)
+            language, locale = self.app_language, self.app_locale
 
         return super().process(
             query_text,

--- a/mindmeld/components/nlp.py
+++ b/mindmeld/components/nlp.py
@@ -248,7 +248,8 @@ class Processor(ABC):
                 where smart_home is the domain and close_door is the intent.
             locale (str, optional): The locale representing the ISO 639-1 language code and \
                 ISO3166 alpha 2 country code separated by an underscore character.
-            language (str, optional): Language as specified using a 639-1/2 code
+            language (str, optional): Language as specified using a 639-1/2 code. This parameter is
+                deprecated deprecated this is an application level parameter.
             time_zone (str, optional): The name of an IANA time zone, such as \
                 'America/Los_Angeles', or 'Asia/Kolkata' \
                 See the [tz database](https://www.iana.org/time-zones) for more information.
@@ -262,6 +263,7 @@ class Processor(ABC):
                  applying the full hierarchy of natural language processing models to the input \
                  query.
         """
+        # TODO: Deprecate language argument
         del language
 
         query = self.create_query(
@@ -340,8 +342,8 @@ class Processor(ABC):
         locale = locale or self.locale
         if locale.split("_")[0].lower() != self.language.lower():
             raise MindMeldError(
-                "Locale %s is inconsistent with "
-                "app language %s" % (locale, self.language)
+                "Locale %s is inconsistent with app language code %s. "
+                "Set the language code in the config.py file." % (locale, self.language)
             )
         return locale
 
@@ -691,7 +693,8 @@ class NaturalLanguageProcessor(Processor):
                 the NLP processing.
             locale (str, optional): The locale representing the ISO 639-1 language code and
                 ISO3166 alpha 2 country code separated by an underscore character.
-            language (str, optional): Language as specified using a 639-1/2 code.
+            language (str, optional): Language as specified using a 639-1/2 code. This parameter is
+                ignored deprecated this is an application level parameter.
             time_zone (str, optional): The name of an IANA time zone, such as \
                 'America/Los_Angeles', or 'Asia/Kolkata' \
                 See the [tz database](https://www.iana.org/time-zones) for more information.
@@ -705,6 +708,7 @@ class NaturalLanguageProcessor(Processor):
                 applying the full hierarchy of natural language processing models to the input \
                 query.
         """
+        # TODO: Deprecate language argument
         del language
 
         if allowed_intents is not None and allowed_nlp_classes is not None:
@@ -843,6 +847,7 @@ class DomainProcessor(Processor):
             (ProcessedQuery): A processed query object that contains the prediction results from \
                 applying the hierarchy of natural language processing models to the input text.
         """
+        # TODO: Deprecate language argument
         del language
 
         query = self.create_query(
@@ -1099,6 +1104,7 @@ class IntentProcessor(Processor):
             (ProcessedQuery): A processed query object that contains the prediction results from \
                 applying the hierarchy of natural language processing models to the input text.
         """
+        # TODO: Deprecate language argument
         del language
         del allowed_nlp_classes
 

--- a/tests/components/test_dialogue.py
+++ b/tests/components/test_dialogue.py
@@ -85,7 +85,9 @@ def test_dialogue_state_rule_unexpected_keyword():
             dialogue_state="some-state", domain="some-domain", new_key="some-key"
         )
 
-    assert "DialogueStateRule() got an unexpected keyword argument 'new_key'" in str(ex)
+    assert "DialogueStateRule() got an unexpected keyword argument 'new_key'" in str(
+        ex.value
+    )
 
 
 def test_dialogue_state_rule_targeted_only():
@@ -103,7 +105,7 @@ def test_dialogue_state_rule_targeted_only():
         " must be omitted"
     )
 
-    assert msg in str(ex)
+    assert msg in str(ex.value)
 
 
 def test_dialogue_state_rule_exception():
@@ -292,10 +294,18 @@ def test_convo_params_are_cleared(kwik_e_mart_nlp, kwik_e_mart_app_path):
         ("en", "en_GB", {"lang": "EN", "latent": True, "locale": "en_GB"}),
         ("es", "en_US", {"lang": "EN", "latent": True, "locale": "en_US"}),
         (None, None, {"latent": True, "locale": "en_CA", "lang": "EN"}),
-        ("INVALID_LANG_CODE", "en_GB", {"lang": "EN", "latent": True, "locale": "en_GB"}),
+        (
+            "INVALID_LANG_CODE",
+            "en_GB",
+            {"lang": "EN", "latent": True, "locale": "en_GB"},
+        ),
         (None, "en_GB", {"lang": "EN", "latent": True, "locale": "en_GB"}),
-        ("es", None, {"lang": "EN", "latent": True}),
-        ("es", "INVALID_LOCALE_CODE", {"lang": "EN", "latent": True}),
+        ("es", None, {"lang": "EN", "latent": True, "locale": "en_CA"}),
+        (
+            "es",
+            "INVALID_LOCALE_CODE",
+            {"lang": "EN", "latent": True, "locale": "en_CA"},
+        ),
         ("eng", "en_GB", {"lang": "EN", "latent": True, "locale": "en_GB"}),
     ],
 )

--- a/tests/components/test_dialogue.py
+++ b/tests/components/test_dialogue.py
@@ -290,12 +290,12 @@ def test_convo_params_are_cleared(kwik_e_mart_nlp, kwik_e_mart_app_path):
     "language, locale, expected_ser_call",
     [
         ("en", "en_GB", {"lang": "EN", "latent": True, "locale": "en_GB"}),
-        ("es", "en_US", {"latent": True, "locale": "en_US"}),
+        ("es", "en_US", {"lang": "EN", "latent": True, "locale": "en_US"}),
         (None, None, {"latent": True, "locale": "en_CA", "lang": "EN"}),
-        ("INVALID_LANG_CODE", "en_GB", {"latent": True, "locale": "en_GB"}),
-        (None, "en_GB", {"latent": True, "locale": "en_GB"}),
-        ("es", None, {"lang": "ES", "latent": True}),
-        ("es", "INVALID_LOCALE_CODE", {"lang": "ES", "latent": True}),
+        ("INVALID_LANG_CODE", "en_GB", {"lang": "EN", "latent": True, "locale": "en_GB"}),
+        (None, "en_GB", {"lang": "EN", "latent": True, "locale": "en_GB"}),
+        ("es", None, {"lang": "EN", "latent": True}),
+        ("es", "INVALID_LOCALE_CODE", {"lang": "EN", "latent": True}),
         ("eng", "en_GB", {"lang": "EN", "latent": True, "locale": "en_GB"}),
     ],
 )


### PR DESCRIPTION
This PR does the following:
1. Removes the use of Language param (but does not deprecate) from the process apis since this cannot be changed for each Mindmeld application
2. Adds app-level language and locale fields to the Processor class so that we don't check against the config.py file every-time we want to read the language/locale for a query.