### PR TITLE
Adding CustomAction and custom action handler in Application

### DIFF
--- a/mindmeld/app.py
+++ b/mindmeld/app.py
@@ -184,25 +184,16 @@ class Application:
                 "`action` or `actions` must be present in arguments."
             )
 
-        if action:
-            self.add_custom_action(
-                action,
-                asynch=kwargs.pop("asynch", False),
-                overwrite=kwargs.pop("overwrite", False),
-                config=kwargs.pop("config", None),
-                **kwargs
-            )
-        else:
-            self.add_custom_action_sequence(
-                actions,
-                asynch=kwargs.pop("asynch", False),
-                overwrite=kwargs.pop("overwrite", False),
-                config=kwargs.pop("config", None),
-                **kwargs
-            )
+        self.add_custom_action_sequence(
+            [action] if action else actions,
+            async_mode=kwargs.pop("async_mode", False),
+            overwrite=kwargs.pop("overwrite", False),
+            config=kwargs.pop("config", None),
+            **kwargs
+        )
 
     def add_custom_action(
-        self, action, asynch=False, overwrite=False, config=None, **kwargs
+        self, action, async_mode=False, overwrite=False, config=None, **kwargs
     ):
         """Adds a custom action handler for the dialogue manager.
 
@@ -211,7 +202,7 @@ class Application:
 
         Args:
             action (str): The name of the custom action
-            asynch (bool): Whether we should invoke this custom action asynchronously
+            async_mode (bool): Whether we should invoke this custom action asynchronously
             overwrite (bool): Whether we should overwrite the Responder with fields from the
                 response, otherwise we will extend the fields (frame, directives) accordingly.
             config (dict): The custom action config, if different from the application's.
@@ -225,13 +216,13 @@ class Application:
 
         custom_action = CustomAction(action, config, overwrite=overwrite)
         state_name = kwargs.pop("name", "custom_action_{}".format(action))
-        if asynch:
+        if async_mode:
             self.add_dialogue_rule(state_name, custom_action.invoke_async, **kwargs)
         else:
             self.add_dialogue_rule(state_name, custom_action.invoke, **kwargs)
 
     def add_custom_action_sequence(
-        self, actions, asynch=False, overwrite=False, config=None, **kwargs
+        self, actions, async_mode=False, overwrite=False, config=None, **kwargs
     ):
         """Adds a custom action sequence handler for the dialogue manager.
 
@@ -240,7 +231,7 @@ class Application:
 
         Args:
             actions (list): A list of custom actions
-            asynch (bool): Whether we should invoke this custom action asynchronously
+            async_mode (bool): Whether we should invoke this custom action asynchronously
             overwrite (bool): Whether we should overwrite the Responder with fields from the
                 response, otherwise we will extend the fields (frame, directives) accordingly.
             config (dict): The custom action config, if different from the application's.
@@ -254,7 +245,7 @@ class Application:
 
         action_seq = CustomActionSequence(actions, config, overwrite=overwrite)
         state_name = kwargs.pop("name", "custom_actions_{}".format(actions))
-        if asynch:
+        if async_mode:
             self.add_dialogue_rule(state_name, action_seq.invoke_async, **kwargs)
         else:
             self.add_dialogue_rule(state_name, action_seq.invoke, **kwargs)

--- a/mindmeld/app.py
+++ b/mindmeld/app.py
@@ -21,7 +21,11 @@ import sys
 from .app_manager import ApplicationManager
 from .cli import app_cli
 from .components._config import get_custom_action_config
-from .components.custom_action import CustomAction, CustomActionException
+from .components.custom_action import (
+    CustomAction,
+    CustomActionException,
+    CustomActionSequence,
+)
 from .components.dialogue import DialogueFlow, DialogueResponder, AutoEntityFilling
 from .components.request import Request
 from .server import MindMeldServer
@@ -172,15 +176,30 @@ class Application:
             app.custom_action(intent='greeting', action='say_greeting')
             app.custom_action(entity='person', action='greet_person')
         """
-        if "action" not in kwargs:
-            raise CustomActionException("`action` is a required argument.")
-        self.add_custom_action(
-            kwargs.pop("action"),
-            asynch=kwargs.pop("asynch", False),
-            overwrite=kwargs.pop("overwrite", False),
-            config=kwargs.pop("config", None),
-            **kwargs
-        )
+        action = kwargs.pop("action", None)
+        actions = kwargs.pop("actions", None)
+
+        if not (action or actions):
+            raise CustomActionException(
+                "`action` or `actions` must be present in arguments."
+            )
+
+        if action:
+            self.add_custom_action(
+                action,
+                asynch=kwargs.pop("asynch", False),
+                overwrite=kwargs.pop("overwrite", False),
+                config=kwargs.pop("config", None),
+                **kwargs
+            )
+        else:
+            self.add_custom_action_sequence(
+                actions,
+                asynch=kwargs.pop("asynch", False),
+                overwrite=kwargs.pop("overwrite", False),
+                config=kwargs.pop("config", None),
+                **kwargs
+            )
 
     def add_custom_action(
         self, action, asynch=False, overwrite=False, config=None, **kwargs
@@ -210,6 +229,35 @@ class Application:
             self.add_dialogue_rule(state_name, custom_action.invoke_async, **kwargs)
         else:
             self.add_dialogue_rule(state_name, custom_action.invoke, **kwargs)
+
+    def add_custom_action_sequence(
+        self, actions, asynch=False, overwrite=False, config=None, **kwargs
+    ):
+        """Adds a custom action sequence handler for the dialogue manager.
+
+        Whenever the user hits this state, we invoke the sequence of custom actions and returns
+            the appropriate responder.
+
+        Args:
+            actions (list): A list of custom actions
+            asynch (bool): Whether we should invoke this custom action asynchronously
+            overwrite (bool): Whether we should overwrite the Responder with fields from the
+                response, otherwise we will extend the fields (frame, directives) accordingly.
+            config (dict): The custom action config, if different from the application's.
+        """
+        if not actions:
+            raise CustomActionException("Argument `actions` should not be empty.")
+
+        config = config or self.custom_action_config
+        if not config:
+            raise CustomActionException("Argument `config` should not be empty.")
+
+        action_seq = CustomActionSequence(actions, config, overwrite=overwrite)
+        state_name = kwargs.pop("name", "custom_actions_{}".format(actions))
+        if asynch:
+            self.add_dialogue_rule(state_name, action_seq.invoke_async, **kwargs)
+        else:
+            self.add_dialogue_rule(state_name, action_seq.invoke, **kwargs)
 
     def dialogue_flow(self, **kwargs):
         """Creates a dialogue flow for the application"""

--- a/mindmeld/app.py
+++ b/mindmeld/app.py
@@ -200,7 +200,7 @@ class Application:
                 "There is no configuration specified for this action."
             )
 
-        actions = [action] or actions
+        actions = [action] if action else actions
         action_seq = CustomActionSequence(actions, config, merge=merge)
         state_name = kwargs.pop("name", "custom_actions_{}".format(actions))
         if async_mode:

--- a/mindmeld/components/__init__.py
+++ b/mindmeld/components/__init__.py
@@ -18,9 +18,11 @@ from .nlp import NaturalLanguageProcessor
 from .preprocessor import Preprocessor
 from .question_answerer import QuestionAnswerer
 from .request import Request
+from .custom_action import CustomAction
 
 __all__ = [
     "Conversation",
+    "CustomAction",
     "DialogueResponder",
     "DialogueManager",
     "NaturalLanguageProcessor",

--- a/mindmeld/components/__init__.py
+++ b/mindmeld/components/__init__.py
@@ -18,11 +18,17 @@ from .nlp import NaturalLanguageProcessor
 from .preprocessor import Preprocessor
 from .question_answerer import QuestionAnswerer
 from .request import Request
-from .custom_action import CustomAction
+from .custom_action import (
+    CustomAction,
+    CustomActionSequence,
+    invoke_custom_action,
+    invoke_custom_action_async,
+)
 
 __all__ = [
     "Conversation",
     "CustomAction",
+    "CustomActionSequence",
     "DialogueResponder",
     "DialogueManager",
     "NaturalLanguageProcessor",
@@ -30,4 +36,6 @@ __all__ = [
     "EntityResolver",
     "Preprocessor",
     "Request",
+    "invoke_custom_action",
+    "invoke_custom_action_async",
 ]

--- a/mindmeld/components/_config.py
+++ b/mindmeld/components/_config.py
@@ -472,6 +472,19 @@ class NlpConfigError(Exception):
     pass
 
 
+def get_custom_action_config(app_path):
+    if not app_path:
+        return None
+    try:
+        custom_action_config = getattr(
+            _get_config_module(app_path), "CUSTOM_ACTION_CONFIG", None
+        )
+        return custom_action_config
+    except (OSError, IOError):
+        logger.info("No app configuration file found.")
+        return None
+
+
 def get_language_config(app_path):
     if not app_path:
         return ENGLISH_LANGUAGE_CODE, ENGLISH_US_LOCALE

--- a/mindmeld/components/_config.py
+++ b/mindmeld/components/_config.py
@@ -481,7 +481,7 @@ def get_custom_action_config(app_path):
         )
         return custom_action_config
     except (OSError, IOError):
-        logger.info("No app configuration file found.")
+        logger.error("No app configuration file found.")
         return None
 
 

--- a/mindmeld/components/custom_action.py
+++ b/mindmeld/components/custom_action.py
@@ -70,8 +70,6 @@ class CustomAction:
                 return self._process_async(json_data, responder)
             else:
                 return self._process(json_data, responder)
-
-            return self._process_post_response(status_code, result_json, responder)
         except ConnectionError:
             logger.error(
                 "Connection error trying to reach custom action server %s.", self.url
@@ -90,7 +88,7 @@ class CustomAction:
         Returns:
             (bool)
         """
-        return self.invoke(request, responder, async_mode=True)
+        return await self.invoke(request, responder, async_mode=True)
 
     def _process(self, json_data, responder):
         status_code, result_json = self.post(json_data)
@@ -133,7 +131,7 @@ class CustomAction:
 
     async def post_async(self, json_data):
         async with aiohttp.ClientSession() as session:
-            async with await session.post(self.url, json=json_data) as response:
+            async with session.post(self.url, json=json_data) as response:
                 if response.status == 200:
                     return 200, await response.json()
                 else:

--- a/mindmeld/components/custom_action.py
+++ b/mindmeld/components/custom_action.py
@@ -101,7 +101,7 @@ class CustomAction:
             for field in RESPONSE_FIELDS:
                 if field not in result_json:
                     logger.warning(
-                        "`%s` not in the response of custom action %s",
+                        "`%s` not in the response of custom action %s.",
                         field,
                         self._name,
                     )

--- a/mindmeld/components/custom_action.py
+++ b/mindmeld/components/custom_action.py
@@ -109,11 +109,19 @@ class CustomAction:
                 responder.frame.update(result_json.get("frame", {}))
                 responder.directives.extend(result_json.get("directives", []))
                 responder.slots.update(result_json.get("slots", {}))
+                params = Params(**result_json.get("params", {}))
+                responder.params.allowed_intents += tuple(params.allowed_intents)
+                responder.params.dynamic_resource.update(params.dynamic_resource)
+                responder.params.time_zone = params.time_zone
+                responder.params.language = params.language
+                responder.params.locale = params.locale
+                responder.params.target_dialogue_state = params.target_dialogue_state
+                responder.params.timestamp = params.timestamp
             else:
                 responder.frame = result_json.get("frame", {})
                 responder.directives = result_json.get("directives", [])
                 responder.slots = result_json.get("slots", {})
-            responder.params = Params(**result_json.get("params", {}))
+                responder.params = Params(**result_json.get("params", {}))
             return True
         else:
             logger.error(

--- a/mindmeld/components/custom_action.py
+++ b/mindmeld/components/custom_action.py
@@ -163,7 +163,7 @@ class CustomActionSequence:
         for action in self.actions:
             result = action.invoke(request, responder)
             if not result:
-                logger.warning("Failed to invoke action:", action)
+                logger.warning("Failed to invoke action %s.", action)
                 return False
         return True
 
@@ -171,7 +171,7 @@ class CustomActionSequence:
         for action in self.actions:
             result = await action.invoke_async(request, responder)
             if not result:
-                logger.warning("Failed to invoke action:", action)
+                logger.warning("Failed to invoke action %s.", action)
                 return False
         return True
 

--- a/mindmeld/components/custom_action.py
+++ b/mindmeld/components/custom_action.py
@@ -1,0 +1,194 @@
+import logging
+
+import aiohttp
+import requests
+
+from .dialogue import DialogueResponder
+
+
+logger = logging.getLogger(__name__)
+
+
+RESPONSE_FIELDS = ["frame", "directives"]
+
+
+class CustomActionException(Exception):
+    pass
+
+
+class CustomAction:
+    """
+    This class allows the client to send Request and Responder to another server and return the
+      the directives and frame in the response.
+    """
+
+    def __init__(self, name: str, config: dict, overwrite: bool = False):
+        self._name = name
+        self._config = config or {}
+        self.url = self._config.get("url")
+        self.overwrite = overwrite
+
+    def get_json_payload(self, request, responder):
+        request_json = {
+            "text": request.text,
+            "domain": request.domain,
+            "intent": request.intent,
+            "context": dict(request.context),
+            "params": request.params.to_dict(),
+            "frame": dict(request.frame),
+        }
+        responder_json = DialogueResponder.to_json(responder)
+        return {
+            "request": request_json,
+            "responder": {field: responder_json[field] for field in RESPONSE_FIELDS},
+            "action": self._name,
+        }
+
+    def invoke(self, request, responder):
+        """Invoke the custom action with Request and Responder and return True if the action is
+        executed successfully, False otherwise. Upon successful execution, we update the Frame
+        and Directives of the Responder object.
+
+        Args:
+            request (Request)
+            responder (DialogueResponder)
+
+        Returns:
+            (bool)
+        """
+        if not self.url:
+            raise CustomActionException(
+                "No URL is given for custom action {}.".format(self._name)
+            )
+
+        json_data = self.get_json_payload(request, responder)
+
+        try:
+            status_code, result_json = self.post(json_data)
+
+            return self._process_response(status_code, result_json, responder)
+        except ConnectionError:
+            logger.error(
+                "Connection error trying to reach custom action server %s.", self.url
+            )
+            return False
+
+    async def invoke_async(self, request, responder):
+        """Asynchronously invoke the custom action with Request and Responder and return True if
+        the action is executed successfully, False otherwise. Upon successful execution, we update
+        the Frame and Directives of the Responder object.
+
+        Args:
+            request (Request)
+            responder (DialogueResponder)
+
+        Returns:
+            (bool)
+        """
+        if not self.url:
+            raise CustomActionException(
+                "No URL is given for custom action {}.".format(self._name)
+            )
+
+        json_data = self.get_json_payload(request, responder)
+
+        try:
+            status_code, result_json = await self.post_async(json_data)
+
+            return self._process_response(status_code, result_json, responder)
+        except ConnectionError:
+            logger.error(
+                "Connection error trying to reach custom action server %s.", self.url
+            )
+            return False
+
+    def _process_response(self, status_code, result_json, responder):
+        if status_code == 200:
+            for field in RESPONSE_FIELDS:
+                if field not in result_json:
+                    logger.warning(
+                        "`%s` not in the response of custom action %s",
+                        field,
+                        self._name,
+                    )
+            if self.overwrite:
+                responder.frame = result_json.get("frame", {})
+                responder.directives = result_json.get("directives", [])
+            else:
+                responder.frame.update(result_json.get("frame", {}))
+                responder.directives.extend(result_json.get("directives", []))
+            return True
+        else:
+            logger.error(
+                "Error %s trying to reach custom action server %s.",
+                status_code,
+                self.url,
+            )
+            return False
+
+    def post(self, json_data):
+        result = requests.post(url=self.url, json=json_data)
+        if result.status_code == 200:
+            return 200, result.json()
+        else:
+            return result.status_code, {}
+
+    async def post_async(self, json_data):
+        async with aiohttp.ClientSession() as session:
+            async with session.post(self.url, json=json_data) as response:
+                if response.status == 200:
+                    json_response = await response.json()
+                    return 200, json_response
+                else:
+                    return response.status, {}
+
+    def __repr__(self):
+        return self._name
+
+    def __str__(self):
+        return self._name
+
+
+class CustomActionSequence:
+    """
+    This class implements a sequence of custom actions
+    """
+
+    def __init__(self, actions, config, overwrite=None):
+        self.actions = [
+            CustomAction(action, config, overwrite=overwrite) for action in actions
+        ]
+
+    def invoke(self, request, responder):
+        for action in self.actions:
+            result = action.invoke(request, responder)
+            if not result:
+                logger.warning("Failed to invoke action:", action)
+                return False
+        return True
+
+    async def invoke_async(self, request, responder):
+        for action in self.actions:
+            result = await action.invoke_async(request, responder)
+            if not result:
+                logger.warning("Failed to invoke action:", action)
+                return False
+        return True
+
+    def __repr__(self):
+        return str(self.actions)
+
+    def __str__(self):
+        return "action_seq=" + str(self.actions)
+
+
+def invoke_custom_action(name, config, request, responder, overwrite=False):
+    return CustomAction(name, config=config, overwrite=overwrite).invoke(
+        request, responder
+    )
+
+
+async def invoke_custom_action_async(name, config, request, responder, overwrite=False):
+    return await CustomAction(name, config=config, overwrite=overwrite).invoke_async(
+        request, responder
+    )

--- a/mindmeld/components/dialogue.py
+++ b/mindmeld/components/dialogue.py
@@ -424,7 +424,8 @@ class DialogueManager:
         res = handler(request, responder)
 
         # Add dialogue flow's sub-dialogue_state if provided
-        if res and "dialogue_state" in res:
+        if res and isinstance(res, dict) and "dialogue_state" in res:
+            # TODO: check if this flow is executed, currently not covered in tests
             dialogue_state = ".".join([dialogue_state, res["dialogue_state"]])
         responder.dialogue_state = dialogue_state
         return responder

--- a/mindmeld/components/dialogue.py
+++ b/mindmeld/components/dialogue.py
@@ -483,7 +483,12 @@ class DialogueManager:
         result_handler = await handler(request, responder)
 
         # Add dialogue flow's sub-dialogue_state if provided
-        if result_handler and "dialogue_state" in result_handler:
+        if (
+            result_handler
+            and isinstance(result_handler, dict)
+            and "dialogue_state" in result_handler
+        ):
+            # TODO: check if this flow is executed, currently not covered in tests
             dialogue_state = "{}.{}".format(
                 dialogue_state, result_handler["dialogue_state"]
             )

--- a/mindmeld/components/request.py
+++ b/mindmeld/components/request.py
@@ -334,3 +334,13 @@ class Request:
     nbest_transcripts_text = attr.ib(default=attr.Factory(tuple), converter=tuple)
     nbest_transcripts_entities = attr.ib(default=attr.Factory(tuple), converter=tuple)
     nbest_aligned_entities = attr.ib(default=attr.Factory(tuple), converter=tuple)
+
+    def to_dict(self):
+        return {
+            "text": self.text,
+            "domain": self.domain,
+            "intent": self.intent,
+            "context": dict(self.context),
+            "params": self.params.to_dict(),
+            "frame": dict(self.frame),
+        }

--- a/mindmeld/converter/rasa.py
+++ b/mindmeld/converter/rasa.py
@@ -596,8 +596,6 @@ __all__ = ['app']
             training data may contain entities
 
         limitations:
-        - Rasa has the ability to have custom actions, which is not supported by
-        the converter.
         - Rasa has the ability to handle multiple intents per query, while Mindmeld
         does not.
         - Rasa training data may be json format, which is not currently supported.

--- a/mindmeld/models/model.py
+++ b/mindmeld/models/model.py
@@ -1295,9 +1295,10 @@ class EntityLabelEncoder(LabelEncoder):
             list: A list of decoded labels per query
         """
         # TODO: support decoding multiple queries at once
+        system_entity_recognizer = SystemEntityRecognizer.get_instance()
         examples = kwargs["examples"]
         labels = [
-            get_entities_from_tags(examples[idx], tags, self.system_entity_recognizer)
+            get_entities_from_tags(examples[idx], tags, system_entity_recognizer)
             for idx, tags in enumerate(tags_by_example)
         ]
         return labels

--- a/mindmeld/models/model.py
+++ b/mindmeld/models/model.py
@@ -1288,17 +1288,16 @@ class EntityLabelEncoder(LabelEncoder):
 
         Args:
             tags_by_example (list): A list of tags per query
-            kwargs (dict): A dict containing atleast the "examples" key, which is a
+            kwargs (dict): A dict containing at least the "examples" key, which is a
                 list of queries to process
 
         Returns:
             list: A list of decoded labels per query
         """
         # TODO: support decoding multiple queries at once
-        system_entity_recognizer = SystemEntityRecognizer.get_instance()
         examples = kwargs["examples"]
         labels = [
-            get_entities_from_tags(examples[idx], tags, system_entity_recognizer)
+            get_entities_from_tags(examples[idx], tags, self.system_entity_recognizer)
             for idx, tags in enumerate(tags_by_example)
         ]
         return labels

--- a/mindmeld/openapi/custom_action.yaml
+++ b/mindmeld/openapi/custom_action.yaml
@@ -179,6 +179,9 @@ definitions:
         type: object
         $ref: '#/definitions/Params'
         description: "The params object of the responder, which contains parameters that influence the operations of the Dialogue Manager"
+      slots:
+        type: object
+        description: "The slots object of the responder, which contains key-value pairs that can be used to render the natural language responses"
 externalDocs:
   description: "Find out more about MindMeld"
   url: "http://www.mindmeld.com"

--- a/mindmeld/openapi/custom_action.yaml
+++ b/mindmeld/openapi/custom_action.yaml
@@ -1,0 +1,184 @@
+swagger: "2.0"
+info:
+  description: "This is an OpenAPI specification for MindMeld Action Server."
+  version: "1.0.0"
+  title: "MindMeld Action Server"
+basePath: "/v2"
+schemes:
+- "https"
+- "http"
+paths:
+  /action:
+    post:
+      summary: "Invoke an action "
+      description: ""
+      operationId: "invokeAction"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "data"
+        description: "MindMeld Data"
+        required: true
+        schema:
+          $ref: '#/definitions/Data'
+      responses:
+        200:
+          description: "OK"
+          schema:
+            $ref: '#/definitions/Responder'
+        405:
+          description: "Invalid input"
+
+definitions:
+  Data:
+    type: object
+    properties:
+      request:
+        type: object
+        description: "MindMeld request object"
+        $ref: '#/definitions/Request'
+      responder:
+        type: object
+        description: "MindMeld responder object"
+        $ref: '#/definitions/Responder'
+      action:
+        type: string
+        description: ""
+  Request:
+    type: "object"
+    description: "The request object is the object that encapsulates the information sent from the device client to the MM server"
+    properties:
+      text:
+        type: "string"
+        description: "The query text"
+      domain:
+        type: "string"
+        description: "Domain of the current query."
+      intent:
+        type: "string"
+        description: "Intent of the current query."
+      entities:
+        type: "array"
+        description: "A list of entities in the current query."
+        items:
+          type: object
+          $ref: "#/definitions/Entity"
+      context:
+        type: object
+        description: "Map containing front-end client state that is passed to the application from the client in the request."
+      params:
+        type: object
+        $ref: "#/definitions/Params"
+        description: "Map of stored data across multiple dialogue turns."
+  Transcript:
+    type: "object"
+    properties:
+      transcript:
+        type: "string"
+        description: "Transcription"
+      confidence:
+        type: "number"
+        description: "Transcription confidence"
+  Directive:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+        description: "Directive Name"
+      type:
+        type: "string"
+        description: "Directive Type"
+        enum:
+        - "view"
+        - "action"
+      payload:
+        type: "object"
+        description: "JSON payload"
+  Domain:
+    type: object
+    properties:
+      value:
+        type: "string"
+      confidence:
+        type: "number"
+  Intent:
+    type: object
+    properties:
+      value:
+        type: "string"
+      confidence:
+        type: "number"
+  Entity:
+    type: "object"
+    properties:
+      text:
+        type: "string"
+        description: "The text contents that span the entity"
+      type:
+        type: "string"
+        description: "Entity type"
+      role:
+        type: "string"
+        description: "Role type"
+      value:
+        type: "object"
+        description: "The resolved value of the entity"
+      display_text:
+        type: string
+        description: "A human readable text representation of the entity for use in natural language responses."
+      confidence:
+        type: number
+        description: "A confidence value from 0 to 1 about how confident the entity recognizer was for the given class label."
+      is_system_entity:
+        type: boolean
+        description: "True if the entity is a system entity"
+  Params:
+    type: object
+    properties:
+      target_dialogue_state:
+        type: string
+        description: "The name of next turn's dialogue state (if set)"
+      dynamic_resoure:
+        type: string
+        description: "The additional values for gazetteer"
+      allowed_intents:
+        type: array
+        items:
+          type: string
+          description: "The name of the intent"
+        description: "The list of allowed intents for next turn (if set)"
+      time_zone:
+        type: string
+        description: "The time zone of the request"
+      language:
+        type: string
+        description: "The language of the request"
+      locale:
+        type: string
+        description: "The locale of the request"
+      timestamp:
+        type: string
+        description: "The timestamp of the request"
+
+  Responder:
+    type: object
+    properties:
+      directives:
+        type: array
+        description: "The list of directives (such as replies) to be sent to the user"
+        items:
+          type: object
+          $ref: '#/definitions/Directive'
+      frame:
+        type: object
+        description: "The frame object of the responder, which contains key-value pairs to send to the application"
+      params:
+        type: object
+        $ref: '#/definitions/Params'
+        description: "The params object of the responder, which contains parameters that influence the operations of the Dialogue Manager"
+externalDocs:
+  description: "Find out more about MindMeld"
+  url: "http://www.mindmeld.com"

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ with open("README.md") as readme_file:
     readme = readme_file.read()
 
 requirements = [
+    "aiohttp>=3.6.2",
     "attrs>=18.2",  # attrs has a stable API and does not use semver
     "Click~=6.0",
     "click-log==0.1.8",

--- a/tests/components/test_config.py
+++ b/tests/components/test_config.py
@@ -11,7 +11,11 @@ Tests for config module.
 
 import os
 
-from mindmeld.components._config import _expand_parser_config, get_classifier_config
+from mindmeld.components._config import (
+    _expand_parser_config,
+    get_classifier_config,
+    get_custom_action_config,
+)
 
 APP_PATH = os.path.dirname(os.path.abspath(__file__))
 
@@ -137,3 +141,16 @@ def test_get_classifier_config_func_error():
     expected = {"error": "intent", "penalty": "l2", "C": 100}
 
     assert actual == expected
+
+
+def test_custom_action_config(kwik_e_mart_app_path):
+    actual = get_custom_action_config(kwik_e_mart_app_path)
+
+    assert "url" in actual
+    assert actual["url"] == "http://0.0.0.0:8080/"
+
+
+def test_custom_action_config_no_config(home_assistant_app_path):
+    actual = get_custom_action_config(home_assistant_app_path)
+
+    assert actual is None

--- a/tests/components/test_custom_action.py
+++ b/tests/components/test_custom_action.py
@@ -10,7 +10,11 @@ Tests for custom actions.
 import pytest
 from unittest.mock import Mock, patch
 
-from mindmeld.components import CustomAction
+from mindmeld.components import (
+    CustomAction,
+    invoke_custom_action,
+    invoke_custom_action_async,
+)
 from mindmeld.components.dialogue import DialogueResponder
 from mindmeld.components.request import Request
 
@@ -21,7 +25,7 @@ def test_custom_action_config(kwik_e_mart_app):
     assert kwik_e_mart_app.custom_action_config["url"] == "http://0.0.0.0:8080/"
 
 
-def test_custom_action_invoke():
+def test_custom_action():
     action_config = {"url": "http://localhost:8080/v2/action"}
     action = CustomAction(name="action_call_people", config=action_config)
 
@@ -34,12 +38,36 @@ def test_custom_action_invoke():
             text="sing a song", domain="some domain", intent="some intent"
         )
         responder = DialogueResponder()
-        result = action.invoke(request, responder)
-        assert result
+        assert action.invoke(request, responder)
+        assert mock_object.call_args[1]["url"] == action_config["url"]
+        assert "request" in mock_object.call_args[1]["json"]
+        assert "responder" in mock_object.call_args[1]["json"]
+        assert mock_object.call_args[1]["json"]["action"] == "action_call_people"
+
+
+def test_invoke_custom_action():
+    action_config = {"url": "http://localhost:8080/v2/action"}
+
+    with patch("requests.post") as mock_object:
+        mock_object.return_value = Mock()
+        mock_object.return_value.status_code = 200
+        mock_object.return_value.json.return_value = {}
+
+        request = Request(
+            text="sing a song", domain="some domain", intent="some intent"
+        )
+        responder = DialogueResponder()
+        assert invoke_custom_action(
+            "action_call_people", action_config, request, responder
+        )
+        assert mock_object.call_args[1]["url"] == action_config["url"]
+        assert "request" in mock_object.call_args[1]["json"]
+        assert "responder" in mock_object.call_args[1]["json"]
+        assert mock_object.call_args[1]["json"]["action"] == "action_call_people"
 
 
 @pytest.mark.asyncio
-async def test_custom_action_invoke_async():
+async def test_custom_action_async():
     action_config = {"url": "http://localhost:8080/v2/action"}
     action = CustomAction(name="action_call_people", config=action_config)
 
@@ -53,5 +81,31 @@ async def test_custom_action_invoke_async():
             text="sing a song", domain="some domain", intent="some intent"
         )
         responder = DialogueResponder()
-        result = await action.invoke_async(request, responder)
-        assert result
+        assert await action.invoke_async(request, responder)
+        call_args = mock_object.call_args_list[0][0][0]
+        assert "request" in call_args
+        assert "responder" in call_args
+        assert call_args["action"] == "action_call_people"
+
+
+@pytest.mark.asyncio
+async def test_invoke_custom_action_async():
+    action_config = {"url": "http://localhost:8080/v2/action"}
+
+    with patch("mindmeld.components.CustomAction.post_async") as mock_object:
+
+        async def mock_coroutine():
+            return 200, {}
+
+        mock_object.return_value = mock_coroutine()
+        request = Request(
+            text="sing a song", domain="some domain", intent="some intent"
+        )
+        responder = DialogueResponder()
+        assert await invoke_custom_action_async(
+            "action_call_people", action_config, request, responder
+        )
+        call_args = mock_object.call_args_list[0][0][0]
+        assert "request" in call_args
+        assert "responder" in call_args
+        assert call_args["action"] == "action_call_people"

--- a/tests/components/test_custom_action.py
+++ b/tests/components/test_custom_action.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_custom_action
+----------------------------------
+
+Tests for custom actions.
+"""
+
+
+def test_custom_action_config(kwik_e_mart_app):
+    assert kwik_e_mart_app.custom_action_config is not None
+    assert "url" in kwik_e_mart_app.custom_action_config
+    assert kwik_e_mart_app.custom_action_config["url"] == "http://0.0.0.0:8080/"

--- a/tests/components/test_custom_action.py
+++ b/tests/components/test_custom_action.py
@@ -7,9 +7,51 @@ test_custom_action
 
 Tests for custom actions.
 """
+import pytest
+from unittest.mock import Mock, patch
+
+from mindmeld.components import CustomAction
+from mindmeld.components.dialogue import DialogueResponder
+from mindmeld.components.request import Request
 
 
 def test_custom_action_config(kwik_e_mart_app):
     assert kwik_e_mart_app.custom_action_config is not None
     assert "url" in kwik_e_mart_app.custom_action_config
     assert kwik_e_mart_app.custom_action_config["url"] == "http://0.0.0.0:8080/"
+
+
+def test_custom_action_invoke():
+    action_config = {"url": "http://localhost:8080/v2/action"}
+    action = CustomAction(name="action_call_people", config=action_config)
+
+    with patch("requests.post") as mock_object:
+        mock_object.return_value = Mock()
+        mock_object.return_value.status_code = 200
+        mock_object.return_value.json.return_value = {}
+
+        request = Request(
+            text="sing a song", domain="some domain", intent="some intent"
+        )
+        responder = DialogueResponder()
+        result = action.invoke(request, responder)
+        assert result
+
+
+@pytest.mark.asyncio
+async def test_custom_action_invoke_async():
+    action_config = {"url": "http://localhost:8080/v2/action"}
+    action = CustomAction(name="action_call_people", config=action_config)
+
+    with patch("mindmeld.components.CustomAction.post_async") as mock_object:
+
+        async def mock_coroutine():
+            return 200, {}
+
+        mock_object.return_value = mock_coroutine()
+        request = Request(
+            text="sing a song", domain="some domain", intent="some intent"
+        )
+        responder = DialogueResponder()
+        result = await action.invoke_async(request, responder)
+        assert result

--- a/tests/kwik_e_mart/config.py
+++ b/tests/kwik_e_mart/config.py
@@ -1,5 +1,7 @@
 LANGUAGE_CONFIG = {"language": "en", "locale": "en_CA"}
 
+CUSTOM_ACTION_CONFIG = {"url": "http://0.0.0.0:8080/"}
+
 NLP_CONFIG = {
     "resolve_entities_using_nbest_transcripts": ["store_info.get_store_hours"]
 }


### PR DESCRIPTION
This is a PR to add CustomAction and its handler in a MindMeld application.

Essentially we are allowing a 3rd party to handle a MindMeld dialogue turn.

Example:
```
app.custom_action(intent='fetch_info', action=''fetch_info_action')
```

We also support asynchronous requests as well:
```
app.custom_action(intent='fetch_info', action=''fetch_info_action', async=True)
```


Whenever the user hits `fetch_info` intent, the Request and Responder objects are serialized and sent as payload to the custom action URL. The resulting frame and directives are returned as a property of the Responder object.

We do not need to put full attention on the RasaConverter; this PR includes the RasaConverter to also include the usage of CustomAction.

OpenAPI specification: https://app.apiary.io/mindmeldnlp/