### PR TITLE
Reprocessing queries for slot-filling

### DIFF
--- a/mindmeld/components/dialogue.py
+++ b/mindmeld/components/dialogue.py
@@ -933,7 +933,7 @@ class AutoEntityFilling:
                 **processed_query,
             )
 
-        self._app.app_manager.dialogue_manager.apply_handler(request, responder)
+            self._app.app_manager.dialogue_manager.apply_handler(request, responder)
 
     def __call__(self, request, responder):
         """

--- a/tests/components/test_auto_fill.py
+++ b/tests/components/test_auto_fill.py
@@ -62,7 +62,8 @@ def test_auto_fill_exit_flow(kwik_e_mart_app, qa_kwik_e_mart):
 
 @pytest.mark.conversation
 def test_auto_fill_switch_flow(kwik_e_mart_app, qa_kwik_e_mart):
-    """Tests slot-fill switch flow logic."""
+    """Tests flow switching from inside slot filling to another intent when
+        the number of retry attempts are exceeded."""
     convo = Conversation(app=kwik_e_mart_app)
     directives = convo.process("What's the store phone number?").directives
     assert_target_dialogue_state(convo, "send_store_phone")
@@ -76,6 +77,22 @@ def test_auto_fill_switch_flow(kwik_e_mart_app, qa_kwik_e_mart):
 
     directives = convo.process("goodbye").directives
     assert_reply(directives, ["Bye", "Goodbye", "Have a nice day."])
+
+
+@pytest.mark.conversation
+def test_auto_fill_validation_missing_entities(kwik_e_mart_app, qa_kwik_e_mart):
+    """Tests default validation when user input has no entities.
+        Check is to see that flow doesn't break."""
+    convo = Conversation(app=kwik_e_mart_app)
+    directives = convo.process("What's the store phone number?").directives
+    assert_target_dialogue_state(convo, "send_store_phone")
+    assert_reply(directives, "Which store would you like to know about?")
+
+    directives = convo.process("123").directives
+    assert_reply(
+        directives,
+        "Sorry, I did not get you. " "Which store would you like to know about?",
+    )
 
 
 @pytest.mark.conversation

--- a/tests/components/test_auto_fill.py
+++ b/tests/components/test_auto_fill.py
@@ -61,6 +61,24 @@ def test_auto_fill_exit_flow(kwik_e_mart_app, qa_kwik_e_mart):
 
 
 @pytest.mark.conversation
+def test_auto_fill_switch_flow(kwik_e_mart_app, qa_kwik_e_mart):
+    """Tests slot-fill switch flow logic."""
+    convo = Conversation(app=kwik_e_mart_app)
+    directives = convo.process("What's the store phone number?").directives
+    assert_target_dialogue_state(convo, "send_store_phone")
+    assert_reply(directives, "Which store would you like to know about?")
+
+    directives = convo.process("goodbye").directives
+    assert_reply(
+        directives,
+        "Sorry, I did not get you. " "Which store would you like to know about?",
+    )
+
+    directives = convo.process("goodbye").directives
+    assert_reply(directives, ["Bye", "Goodbye", "Have a nice day."])
+
+
+@pytest.mark.conversation
 @pytest.mark.asyncio
 async def test_auto_exit_flow_async(async_kwik_e_mart_app, qa_kwik_e_mart):
     """Tests auto fill for async apps."""


### PR DESCRIPTION
This PR allows slot-filling to use ``allowed_intents`` and reprocess a query when the retry logic is exhausted. Also adds a test to check the same.

This comes from the observation that the in-built ``reprocess`` does not work with allowed_intents set from the previous turn and always reprocesses to those specified intents. This fix by-passes the reprocess call and directly calls the ``apply_handler`` functionality in the DM with a repeat ``nlp.process`` call and creation of a new request object that is passed to the DM as a new query turn.

Also, fixes a validation bug.