### PR TITLE
raise markup error for missing open bracket

### DIFF
--- a/mindmeld/markup.py
+++ b/mindmeld/markup.py
@@ -262,7 +262,7 @@ def process_markup(markup, query_factory, query_options):
         entities = _process_annotations(
             query, annotations, query_factory.system_entity_recognizer,
         )
-    except MarkupError as exc:
+    except (MarkupError, IndexError) as exc:
         msg = "Invalid markup in query {!r}: {}"
         raise MarkupError(msg.format(markup, exc)) from exc
     except SystemEntityResolutionError as exc:
@@ -448,7 +448,7 @@ def _tokenize_markup(markup):
                     open_annotations["entity"] += 1
                 yield char
             elif char == META_SPLIT:
-                # TODO: improve this check
+                # TODO: improve this check to accept {{a|b}|c} but reject {|c} and {a||c}
                 # if not token:
                 #     raise MarkupError('Entity or group text is empty at position {}'.format(idx))
                 if token:

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -9,7 +9,7 @@ Tests for `markup` module.
 """
 import pytest
 
-from mindmeld import markup
+from mindmeld import exceptions, markup
 from mindmeld.core import Entity, NestedEntity, ProcessedQuery, QueryEntity, Span
 
 MARKED_UP_STRS = [
@@ -68,6 +68,26 @@ def test_load_entity(query_factory):
     assert entity.normalized_text == "elm street"
     assert entity.entity.type == "store_name"
     assert entity.entity.text == "Elm Street"
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "book from now|sys_time} until kingdom come",
+        "book {now|sys_time|}",
+        "book {now|sys|[time]}",
+        "book [{now|sys_time} until {later|ref}|range]",
+        "book [{now|sys_time}|range]",
+        "book {now|sys_time]",
+        "book {now|}",
+        "book {now}",
+        "book {now|",
+    ]
+)
+@pytest.mark.load
+def test_load_markup_error(query_factory, query):
+
+    with pytest.raises(exceptions.MarkupError):
+        markup.load_query(query, query_factory)
 
 
 @pytest.mark.load


### PR DESCRIPTION
This PR fixes https://github.com/cisco/mindmeld/issues/148

Because the markup parser is tracking open and close brackets but is not tracking position of the cursor relative to the pipes, the parser can't directly raise a markup error for malformed entities like `now|sys_time}`, `{now||sys_time}` or `{|sys_time}`. But in the case of `now|sys_time}` we will hit an indexerror, and so we are catching that IndexError and raising a MarkupError with a more informative message.

I also added tests for a few other kinds of markup errors that we do catch.