### PR TITLE
Fix input metavar in predict cli command

### DIFF
--- a/mindmeld/cli.py
+++ b/mindmeld/cli.py
@@ -258,7 +258,7 @@ def evaluate(ctx, verbose):
 @click.option(
     "-G", "--no_group", is_flag=True, help="Suppress predicted group annotations"
 )
-@click.argument("input", required=True)
+@click.argument("input_file", envvar="INPUT", metavar="INPUT", required=True)
 def predict(
     ctx,
     input_file,


### PR DESCRIPTION
The `input` argument of the `predict` CLI command got renamed to `input_file` without updating the click argument. This resulted in an error like this:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
...
  File ".pyenv/versions/3.6.5/envs/wxa/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File ".pyenv/versions/3.6.5/envs/wxa/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
TypeError: predict() got an unexpected keyword argument 'input'
```
This updates the click argument definition to pass the INPUT into the function correctly.