### PR TITLE
Rename TestConversation to ConversationTestHelper

### DIFF
--- a/mindmeld/test.py
+++ b/mindmeld/test.py
@@ -16,7 +16,7 @@
 from .components.dialogue import Conversation
 
 
-class TestConversation(Conversation):
+class ConversationTestHelper(Conversation):
     """
     This class is used during testing to assert that we identify the correct domain and intent,
     receive the right text as a response, and navigate to the correct frame.

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,4 +14,5 @@ markers =
     nested: tests which cover nested entities
     role: tests which cover entity roles
     system: tests which cover system entities
-    markdown: tests which cover markdown annotation
+    mark_down: tests which cover markdown annotation
+    special: tests which cover special characters

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,12 @@ markers =
     no_extras: tests which require extras to not be present
     tensorflow: tests which require the tensorflow extra
     no_tensorflow: tests which require the tensorflow extra to not be present
+    conversation: tests which cover a back and forth conversation flow
+    asyncio: tests which are asynchronous
+    dump: tests which cover dumping of data
+    load: tests which cover loading of data
+    group: tests which cover entity grouping
+    nested: tests which cover nested entities
+    role: tests which cover entity roles
+    system: tests which cover system entities
+    markdown: tests which cover markdown annotation

--- a/tests/converter/test_df_converter.py
+++ b/tests/converter/test_df_converter.py
@@ -4,7 +4,7 @@ import shutil
 import importlib
 
 from mindmeld.components import NaturalLanguageProcessor
-from mindmeld.test import TestConversation
+from mindmeld.test import ConversationTestHelper
 from mindmeld.converter.dialogflow import DialogflowConverter
 
 
@@ -68,7 +68,7 @@ def test_df_converter():
     mm_df_app = importlib.import_module("mm_df_converted_project").app
     mm_df_app.lazy_init(mm_df_nlp)
 
-    conv = TestConversation(app=mm_df_app)
+    conv = ConversationTestHelper(app=mm_df_app)
     conv.process("what is my balance")
     conv.assert_text("Here's your latest balance:")
     conv.assert_domain("app_specific")

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,8 +1,8 @@
-from mindmeld.test import TestConversation
+from mindmeld.test import ConversationTestHelper
 
 
 def test_conversation(kwik_e_mart_app_path):
-    conv = TestConversation(app_path=kwik_e_mart_app_path)
+    conv = ConversationTestHelper(app_path=kwik_e_mart_app_path)
     conv.process("hi")
     conv.assert_text(
         "Hello. I can help you find store hours for your local Kwik-E-Mart."


### PR DESCRIPTION
Rename TestConversation to ConversationTestHelper since the pattern "Test*" is reserved for test suites; "TestConversation" triggers a warning from pytest.
