### PR TITLE
Documentation docker command fix

### DIFF
--- a/source/userguide/getting_started.rst
+++ b/source/userguide/getting_started.rst
@@ -35,7 +35,7 @@ In the Docker setup, we use Docker only for running MindMeld dependencies, namel
 .. code-block:: shell
 
    docker pull mindmeldworkbench/dep:latest
-   docker run -p 0.0.0.0:9200:9200 -p 0.0.0.0:7151:7151 -p 0.0.0.0:9300:9300 mindmeldworkbench/dep -ti -d
+   docker run -ti -d -p 0.0.0.0:9200:9200 -p 0.0.0.0:7151:7151 -p 0.0.0.0:9300:9300 mindmeldworkbench/dep
 
 2. Install prerequisites
 """"""""""""""""""""""""


### PR DESCRIPTION
In the documentation for the Getting Started guide, [the docker command provided](https://www.mindmeld.com/docs/userguide/getting_started.html#pull-and-run-docker-container) does not replicate the intended behavior.

See code snippets below:
1) **When the -d flag is kept at the end**:
```bash
vidamoda@VIDAMODA-M-83AB Internship2020 % docker run -p 0.0.0.0:9000:9000 -p 0.0.0.0:7251:7251 -p 0.0.0.0:9400:9400 mindmeldworkbench/dep -ti -d

Collecting mindmeld
  Downloading https://files.pythonhosted.org/packages/ba/72/83ba9dc5c0d5e162f2fc007716991bd7f35ef85bd4fae62cbd154b414bea/mindmeld-4.2.11-py2.py3-none-any.whl (6.4MB)
Collecting future~=0.16.0 (from mindmeld)
  Downloading https://files.pythonhosted.org/packages/00/2b/8d082ddfed935f3608cc61140df6dcbf0edea1bc3ab52fb6c29ae3e81e85/future-0.16.0.tar.gz (824kB)
Collecting Flask~=1.0 (from mindmeld)
  Downloading https://files.pythonhosted.org/packages/f2/28/2a03252dfb9ebf377f40fba6a7841b47083260bf8bd8e737b0c6952df83f/Flask-1.1.2-py2.py3-none-any.whl (94kB)
Requirement already satisfied, skipping upgrade: nltk~=3.2 in /usr/local/lib/python3.5/dist-packages (from mindmeld) (3.4.3)
Requirement already satisfied, skipping upgrade: scikit-learn<0.20,>=0.18.1; python_version < "3.7" in /usr/local/lib/python3.5/dist-packages (from mindmeld) (0.19.2)
Requirement already satisfied, skipping upgrade: numpy~=1.15 in /usr/local/lib/python3.5/dist-packages (from mindmeld) (1.16.4)
Requirement already satisfied, skipping upgrade: elasticsearch5~=5.5 in /usr/local/lib/python3.5/dist-packages (from mindmeld) (5.5.6)
Requirement already satisfied, skipping upgrade: tqdm~=4.15 in /usr/local/lib/python3.5/dist-packages (from mindmeld) (4.32.2)
Requirement already satisfied, skipping upgrade: python-dateutil~=2.6 in /usr/local/lib/python3.5/dist-packages (from mindmeld) (2.8.0)
Collecting pycountry (from mindmeld)
```

2) **When the -d flag is removed**: 
```bash
vidamoda@VIDAMODA-M-83AB Internship2020 % docker run -p 0.0.0.0:9000:9000 -p 0.0.0.0:7251:7251 -p 0.0.0.0:9400:9400 mindmeldworkbench/dep       

Collecting mindmeld
  Downloading https://files.pythonhosted.org/packages/ba/72/83ba9dc5c0d5e162f2fc007716991bd7f35ef85bd4fae62cbd154b414bea/mindmeld-4.2.11-py2.py3-none-any.whl (6.4MB)
Requirement already satisfied, skipping upgrade: pytz in /usr/local/lib/python3.5/dist-packages (from mindmeld) (2019.1)
Requirement already satisfied, skipping upgrade: immutables~=0.9 in /usr/local/lib/python3.5/dist-packages (from mindmeld) (0.9)
Requirement already satisfied, skipping upgrade: attrs>=18.2 in /usr/local/lib/python3.5/dist-packages (from mindmeld) (18.2.0)
Requirement already satisfied, skipping upgrade: Flask-Cors~=3.0 in /usr/local/lib/python3.5/dist-packages (from mindmeld) (3.0.8)
Requirement already satisfied, skipping upgrade: tqdm~=4.15 in /usr/local/lib/python3.5/dist-packages (from mindmeld) (4.32.2)
Requirement already satisfied, skipping upgrade: scipy<2.0,>=0.13.3 in /usr/local/lib/python3.5/dist-packages (from mindmeld) (0.19.1)
Collecting pyyaml>=5.1.1 (from mindmeld)
```

From snippets 1 and 2, the -d flag does not seem to have any effect when added to the end of the command. The expected behavior is to have a docker container running in the background without having to keep a terminal open. This is achieved by moving the -d flag to the front of the snippet _immediately after the run command_.

3) **Correct usage: Moving -d to front**
```bash
vidamoda@VIDAMODA-M-83AB Internship2020 % docker run -ti -d -p 0.0.0.0:9000:9000 -p 0.0.0.0:7251:7251 -p 0.0.0.0:9400:9400 mindmeldworkbench/dep

063c6fcd8a811bfc737541f19d4361133ab8539316c3c7cda4055a60eed48ff8
vidamoda@VIDAMODA-M-83AB Internship2020 % docker ps
CONTAINER ID        IMAGE                   COMMAND                  CREATED             STATUS              PORTS                                                                                                  NAMES
063c6fcd8a81        mindmeldworkbench/dep   "/bin/sh -c 'export …"   5 seconds ago       Up 4 seconds        0.0.0.0:7251->7251/tcp, 7151/tcp, 9200/tcp, 0.0.0.0:9000->9000/tcp, 9300/tcp, 0.0.0.0:9400->9400/tcp   angry_banach
41590e1c6109        mindmeldworkbench/dep   "/bin/sh -c 'export …"   7 hours ago         Up 7 hours          0.0.0.0:7151->7151/tcp, 0.0.0.0:9200->9200/tcp, 0.0.0.0:9300->9300/tcp                                 heuristic_tesla
```