### PR TITLE
Enable user to run 'python -m jukebot converse --verbose' to display intent confidences

### DIFF
--- a/mindmeld/cli.py
+++ b/mindmeld/cli.py
@@ -111,7 +111,13 @@ def run_server(ctx, port, no_debug, reloader):
 @_app_cli.command("converse", context_settings=CONTEXT_SETTINGS)
 @click.pass_context
 @click.option("--context", help="JSON object to be used as the context")
-def converse(ctx, context):
+@click.option(
+    "-v",
+    "--verbose",
+    is_flag=True,
+    help="Print the full metrics instead of just accuracy.",
+)
+def converse(ctx, context, verbose):
     """Starts a conversation with the app."""
 
     try:
@@ -132,7 +138,7 @@ def converse(ctx, context):
             loop.run_until_complete(_converse_async(app, context))
             return
 
-        convo = Conversation(app=app, context=context)
+        convo = Conversation(app=app, context=context, verbose=verbose)
 
         while True:
             message = click.prompt("You")

--- a/mindmeld/cli.py
+++ b/mindmeld/cli.py
@@ -118,7 +118,11 @@ def run_server(ctx, port, no_debug, reloader):
     help="Print the full metrics instead of just accuracy.",
 )
 def converse(ctx, context, verbose):
-    """Starts a conversation with the app."""
+    """
+    Starts a conversation with the app.
+    When the verbose flag is set to true, the confidences are included 
+    in the request objects passed to the intents 
+    """
 
     try:
         app = ctx.obj.get("app")

--- a/mindmeld/components/dialogue.py
+++ b/mindmeld/components/dialogue.py
@@ -1211,7 +1211,7 @@ class Conversation:
         params (FrozenParams): The params returned by the most recent turn.
         force_sync (bool): Force synchronous return for `say()` and `process()` \
             even when app is in async mode.
-	verbose (bool, optional): If True, returns class probabilities along with class \
+        verbose (bool, optional): If True, returns class probabilities along with class \
                 prediction.
     """
 
@@ -1225,7 +1225,7 @@ class Conversation:
         context=None,
         default_params=None,
         force_sync=False,
-	verbose=False
+        verbose=False
     ):
         """
         Args:
@@ -1240,11 +1240,11 @@ class Conversation:
                 defaults will be overridden by params passed for each turn.
             force_sync (bool, optional): Force synchronous return for `say()` and `process()`
                 even when app is in async mode.
-	    verbose (bool, optional): If True, returns class probabilities along with class \
+            verbose (bool, optional): If True, returns class probabilities along with class \
                 prediction.
         """
         app = app or path.get_app(app_path)
-        app.lazy_init(nlp, verbose=verbose)
+        app.lazy_init(nlp)
         self._app_manager = app.app_manager
         if not self._app_manager.ready:
             self._app_manager.load()
@@ -1254,7 +1254,7 @@ class Conversation:
         self.default_params = default_params or Params()
         self.force_sync = force_sync
         self.params = FrozenParams()
-	self.verbose = verbose	
+        self.verbose = verbose	
 
     def say(self, text, params=None, force_sync=False):
         """Send a message in the conversation. The message will be
@@ -1346,7 +1346,7 @@ class Conversation:
             frame=self.frame,
             history=self.history,
             verbose=self.verbose
-	)
+        )
         self.history = response.history
         self.frame = response.frame
         self.params = response.params

--- a/mindmeld/components/dialogue.py
+++ b/mindmeld/components/dialogue.py
@@ -1211,6 +1211,8 @@ class Conversation:
         params (FrozenParams): The params returned by the most recent turn.
         force_sync (bool): Force synchronous return for `say()` and `process()` \
             even when app is in async mode.
+	verbose (bool, optional): If True, returns class probabilities along with class \
+                prediction.
     """
 
     _logger = mod_logger.getChild("Conversation")
@@ -1223,6 +1225,7 @@ class Conversation:
         context=None,
         default_params=None,
         force_sync=False,
+	verbose=False
     ):
         """
         Args:
@@ -1237,9 +1240,11 @@ class Conversation:
                 defaults will be overridden by params passed for each turn.
             force_sync (bool, optional): Force synchronous return for `say()` and `process()`
                 even when app is in async mode.
+	    verbose (bool, optional): If True, returns class probabilities along with class \
+                prediction.
         """
         app = app or path.get_app(app_path)
-        app.lazy_init(nlp)
+        app.lazy_init(nlp, verbose=verbose)
         self._app_manager = app.app_manager
         if not self._app_manager.ready:
             self._app_manager.load()
@@ -1249,6 +1254,7 @@ class Conversation:
         self.default_params = default_params or Params()
         self.force_sync = force_sync
         self.params = FrozenParams()
+	self.verbose = verbose	
 
     def say(self, text, params=None, force_sync=False):
         """Send a message in the conversation. The message will be
@@ -1339,7 +1345,8 @@ class Conversation:
             context=self.context,
             frame=self.frame,
             history=self.history,
-        )
+            verbose=self.verbose
+	)
         self.history = response.history
         self.frame = response.frame
         self.params = response.params

--- a/mindmeld/components/dialogue.py
+++ b/mindmeld/components/dialogue.py
@@ -1387,6 +1387,7 @@ class Conversation:
             context=self.context,
             frame=self.frame,
             history=self.history,
+            verbose=self.verbose
         )
         self.history = response.history
         self.frame = response.frame


### PR DESCRIPTION
I couldn't figure out a way to show the confidences (intent probabilities) while conversing, and it would be great if we had that option.