### PR TITLE
Updated Dockerfiles to use Ubuntu 18.04 and Python 3.6.9 to solve aiohttp Docker build issue

### DIFF
--- a/docker_containers/mindmeld_dep_docker/Dockerfile
+++ b/docker_containers/mindmeld_dep_docker/Dockerfile
@@ -8,7 +8,7 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 # Pull base image.
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV ES_PKG_NAME elasticsearch-5.5.1
 
@@ -21,7 +21,7 @@ RUN mkdir /root/.pip /root/.mindmeld /data
 
 # Install python pip
 RUN apt-get -y install python-pip python3-pip python-dev build-essential && \
-    apt-get -y install python-software-properties
+    apt-get -y install software-properties-common
 
 # Install Java
 RUN apt update
@@ -31,7 +31,7 @@ RUN apt install openjdk-8-jdk -y
 
 # Install duckling dependency
 RUN apt-get -y update && \
-    apt-get -y upgrade tzdata
+    DEBIAN_FRONTEND="noninteractive" apt-get -y upgrade tzdata
 
 # set JAVA_HOME
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64

--- a/docker_containers/mindmeld_docker/Dockerfile
+++ b/docker_containers/mindmeld_docker/Dockerfile
@@ -8,7 +8,7 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 # Pull base image.
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV ES_PKG_NAME elasticsearch-5.5.1
 
@@ -21,7 +21,7 @@ RUN mkdir /root/.pip /root/.mindmeld /data
 
 # Install python pip
 RUN apt-get -y install python-pip python3-pip python-dev build-essential && \
-    apt-get -y install python-software-properties
+    apt-get -y install software-properties-common
 
 # Install Java
 RUN apt update
@@ -31,7 +31,7 @@ RUN apt install openjdk-8-jdk -y
 
 # Install duckling dependency
 RUN apt-get -y update && \
-    apt-get -y upgrade tzdata
+    DEBIAN_FRONTEND="noninteractive" apt-get -y upgrade tzdata
 
 # set JAVA_HOME
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64


### PR DESCRIPTION
Currently when attempting to build the Docker container build of Mindmeld provided at https://github.com/cisco/mindmeld/blob/master/docker_containers/mindmeld_docker/Dockerfile , the following issue occurs during the Mindmeld package installation step:

![mindmeld-build-error](https://user-images.githubusercontent.com/1192364/86493114-e91b0580-bd35-11ea-9289-11a14755b9bb.png)

Upon checking the build process it seems that the current form of the container installs Python `3.5.2`, which seems to be the version the `16.04` base image of ubuntu uses.  To solve the issue, this PR updates the base image to `18.04` and makes a couple of adjustments so the build completes, causing Python `3.6.9` to be installed instead, which does not run into the aiohttp issue during the Mindmeld installation step.