### PR TITLE
Docker fix for ES 7.8

### DIFF
--- a/docker_containers/mindmeld_dep_docker/Dockerfile
+++ b/docker_containers/mindmeld_dep_docker/Dockerfile
@@ -10,7 +10,8 @@
 # Pull base image.
 FROM ubuntu:18.04
 
-ENV ES_PKG_NAME elasticsearch-5.5.1
+ENV ES_PKG_NAME elasticsearch-7.8.0-linux-x86_64
+ENV ES_FOLDER_NAME elasticsearch-7.8.0
 
 # System packages
 RUN apt-get update && \
@@ -42,7 +43,7 @@ RUN \
     wget https://artifacts.elastic.co/downloads/elasticsearch/$ES_PKG_NAME.tar.gz && \
     tar xvzf $ES_PKG_NAME.tar.gz && \
     rm -f $ES_PKG_NAME.tar.gz && \
-    mv /$ES_PKG_NAME /elasticsearch
+    mv /$ES_FOLDER_NAME /elasticsearch
 
 RUN useradd -ms /bin/bash mindmeld
 RUN mkdir /elasticsearch/log

--- a/docker_containers/mindmeld_dep_docker/conf/elasticsearch.yml
+++ b/docker_containers/mindmeld_dep_docker/conf/elasticsearch.yml
@@ -66,6 +66,9 @@ http.port: 9200
 # The default list of hosts is ["127.0.0.1", "[::1]"]
 #
 #discovery.zen.ping.unicast.hosts: ["host1", "host2"]
+discovery.type: single-node
+#cluster.initial_master_nodes: ["node-1"]
+#discovery.seed_hosts: ["node-1"]
 #
 # Prevent the "split brain" by configuring the majority of nodes (total number of master-eligible nodes / 2 + 1):
 #

--- a/docker_containers/mindmeld_docker/Dockerfile
+++ b/docker_containers/mindmeld_docker/Dockerfile
@@ -10,7 +10,8 @@
 # Pull base image.
 FROM ubuntu:18.04
 
-ENV ES_PKG_NAME elasticsearch-5.5.1
+ENV ES_PKG_NAME elasticsearch-7.8.0-linux-x86_64
+ENV ES_FOLDER_NAME elasticsearch-7.8.0
 
 # System packages
 RUN apt-get update && \
@@ -42,7 +43,7 @@ RUN \
     wget https://artifacts.elastic.co/downloads/elasticsearch/$ES_PKG_NAME.tar.gz && \
     tar xvzf $ES_PKG_NAME.tar.gz && \
     rm -f $ES_PKG_NAME.tar.gz && \
-    mv /$ES_PKG_NAME /elasticsearch
+    mv /$ES_FOLDER_NAME /elasticsearch
 
 RUN useradd -ms /bin/bash mindmeld
 RUN mkdir /elasticsearch/log

--- a/docker_containers/mindmeld_docker/conf/elasticsearch.yml
+++ b/docker_containers/mindmeld_docker/conf/elasticsearch.yml
@@ -66,6 +66,9 @@ path.logs: /elasticsearch/log
 # The default list of hosts is ["127.0.0.1", "[::1]"]
 #
 #discovery.zen.ping.unicast.hosts: ["host1", "host2"]
+discovery.type: single-node
+#cluster.initial_master_nodes: ["node-1"]
+#discovery.seed_hosts: ["node-1"]
 #
 # Prevent the "split brain" by configuring the majority of nodes (total number of master-eligible nodes / 2 + 1):
 #


### PR DESCRIPTION
The present docker containers are using ES 5.5. This PR is related to upgrading it to the latest version of 7.8.0 so that it is compatible with the latest QA embedding code. (See PR #147)

Some breaking changes are present when upgrading to ES7 which are detailed [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#_discovery_configuration_is_required_in_production). 

We have 2 ways of fixing it:
1) Solution 1 is given [here](https://stackoverflow.com/a/59350674). 
The logs look like so 
```
[2020-07-08T23:49:00,888][INFO ][o.e.d.DiscoveryModule    ] [node-1] using discovery type [zen] and seed hosts providers [settings]
[2020-07-08T23:49:03,000][INFO ][o.e.n.Node               ] [node-1] initialized
[2020-07-08T23:49:03,000][INFO ][o.e.n.Node               ] [node-1] starting ...
[2020-07-08T23:49:03,327][INFO ][o.e.t.TransportService   ] [node-1] publish_address {172.17.0.2:9300}, bound_addresses {0.0.0.0:9300}
[2020-07-08T23:49:03,927][INFO ][o.e.b.BootstrapChecks    ] [node-1] bound or publishing to a non-loopback address, enforcing bootstrap checks
[2020-07-08T23:49:03,963][INFO ][o.e.c.c.Coordinator      ] [node-1] cluster UUID [uc4aiqHBQo6BIxdkP6Yfxg]
[2020-07-08T23:49:03,985][WARN ][o.e.d.SeedHostsResolver  ] [node-1] failed to resolve host [node-1]
java.net.UnknownHostException: node-1: Name or service not known
	at java.net.Inet4AddressImpl.lookupAllHostAddr(Native Method) ~[?:1.8.0_252]
	at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:929) ~[?:1.8.0_252]
	at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:1324) ~[?:1.8.0_252]
	at java.net.InetAddress.getAllByName0(InetAddress.java:1277) ~[?:1.8.0_252]
	at java.net.InetAddress.getAllByName(InetAddress.java:1193) ~[?:1.8.0_252]
	at java.net.InetAddress.getAllByName(InetAddress.java:1127) ~[?:1.8.0_252]
	at org.elasticsearch.transport.TcpTransport.parse(TcpTransport.java:548) ~[elasticsearch-7.8.0.jar:7.8.0]
	at org.elasticsearch.transport.TcpTransport.addressesFromString(TcpTransport.java:490) ~[elasticsearch-7.8.0.jar:7.8.0]
	at org.elasticsearch.transport.TransportService.addressesFromString(TransportService.java:856) ~[elasticsearch-7.8.0.jar:7.8.0]
	at org.elasticsearch.discovery.SeedHostsResolver.lambda$resolveHostsLists$0(SeedHostsResolver.java:144) ~[elasticsearch-7.8.0.jar:7.8.0]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_252]
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:636) ~[elasticsearch-7.8.0.jar:7.8.0]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_252]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_252]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_252]
[2020-07-08T23:49:04,129][INFO ][o.e.c.s.MasterService    ] [node-1] elected-as-master ([1] nodes joined)[{node-1}{M7wHL5HEReqd7oBJPlySaQ}{r-5lTBZDTjWQ73YAwxSGFQ}{172.17.0.2}{172.17.0.2:9300}{dilmrt}{ml.machine_memory=2087837696, xpack.installed=true, transform.node=true, ml.max_open_jobs=20} elect leader, _BECOME_MASTER_TASK_, _FINISH_ELECTION_], term: 2, version: 32, delta: master node changed {previous [], current [{node-1}{M7wHL5HEReqd7oBJPlySaQ}{r-5lTBZDTjWQ73YAwxSGFQ}{172.17.0.2}{172.17.0.2:9300}{dilmrt}{ml.machine_memory=2087837696, xpack.installed=true, transform.node=true, ml.max_open_jobs=20}]}
[2020-07-08T23:49:04,259][INFO ][o.e.c.s.ClusterApplierService] [node-1] master node changed {previous [], current [{node-1}{M7wHL5HEReqd7oBJPlySaQ}{r-5lTBZDTjWQ73YAwxSGFQ}{172.17.0.2}{172.17.0.2:9300}{dilmrt}{ml.machine_memory=2087837696, xpack.installed=true, transform.node=true, ml.max_open_jobs=20}]}, term: 2, version: 32, reason: Publication{term=2, version=32}
[2020-07-08T23:49:04,359][INFO ][o.e.h.AbstractHttpServerTransport] [node-1] publish_address {172.17.0.2:9200}, bound_addresses {0.0.0.0:9200}
[2020-07-08T23:49:04,362][INFO ][o.e.n.Node               ] [node-1] started
[2020-07-08T23:49:04,877][INFO ][o.e.l.LicenseService     ] [node-1] license [3f3e9b80-88f1-4894-add1-bd9a2388a171] mode [basic] - valid
[2020-07-08T23:49:04,879][INFO ][o.e.x.s.s.SecurityStatusChangeListener] [node-1] Active license is now [BASIC]; Security is disabled
[2020-07-08T23:49:04,892][INFO ][o.e.g.GatewayService     ] [node-1] recovered [1] indices into cluster_state

```

There seems to be a temporary error which seems to resolve itself shortly. I've added the two lines required for this change as comments in the yml file.

2) The second solution and IMO the cleaner one is [this](https://stackoverflow.com/a/60426167). 

Logs look like so
```
[2020-07-08T23:36:27,381][INFO ][o.e.n.Node               ] [node-1] starting ...
[2020-07-08T23:36:27,737][INFO ][o.e.t.TransportService   ] [node-1] publish_address {172.17.0.2:9300}, bound_addresses {0.0.0.0:9300}
[2020-07-08T23:36:28,170][INFO ][o.e.c.c.Coordinator      ] [node-1] setting initial configuration to VotingConfiguration{O6LPBUjZSp6UOt6_rKtp3w}
[2020-07-08T23:36:28,492][INFO ][o.e.c.s.MasterService    ] [node-1] elected-as-master ([1] nodes joined)[{node-1}{O6LPBUjZSp6UOt6_rKtp3w}{gjlZ3rueSvC-2K7h9CcpoQ}{172.17.0.2}{172.17.0.2:9300}{dilmrt}{ml.machine_memory=2087837696, xpack.installed=true, transform.node=true, ml.max_open_jobs=20} elect leader, _BECOME_MASTER_TASK_, _FINISH_ELECTION_], term: 1, version: 1, delta: master node changed {previous [], current [{node-1}{O6LPBUjZSp6UOt6_rKtp3w}{gjlZ3rueSvC-2K7h9CcpoQ}{172.17.0.2}{172.17.0.2:9300}{dilmrt}{ml.machine_memory=2087837696, xpack.installed=true, transform.node=true, ml.max_open_jobs=20}]}
[2020-07-08T23:36:28,580][INFO ][o.e.c.c.CoordinationState] [node-1] cluster UUID set to [3EYmUWhKQ6OytJTARZBKjg]
[2020-07-08T23:36:28,620][INFO ][o.e.c.s.ClusterApplierService] [node-1] master node changed {previous [], current [{node-1}{O6LPBUjZSp6UOt6_rKtp3w}{gjlZ3rueSvC-2K7h9CcpoQ}{172.17.0.2}{172.17.0.2:9300}{dilmrt}{ml.machine_memory=2087837696, xpack.installed=true, transform.node=true, ml.max_open_jobs=20}]}, term: 1, version: 1, reason: Publication{term=1, version=1}
[2020-07-08T23:36:28,718][INFO ][o.e.h.AbstractHttpServerTransport] [node-1] publish_address {172.17.0.2:9200}, bound_addresses {0.0.0.0:9200}
[2020-07-08T23:36:28,719][INFO ][o.e.n.Node               ] [node-1] started
[2020-07-08T23:36:28,748][INFO ][o.e.x.c.t.IndexTemplateRegistry] [node-1] adding index template [.watch-history-11] for [watcher], because it doesn't exist
[2020-07-08T23:36:28,749][INFO ][o.e.x.c.t.IndexTemplateRegistry] [node-1] adding index template [.triggered_watches] for [watcher], because it doesn't exist
[2020-07-08T23:36:28,750][INFO ][o.e.x.c.t.IndexTemplateRegistry] [node-1] adding index template [.watches] for [watcher], because it doesn't exist
[2020-07-08T23:36:28,815][INFO ][o.e.x.c.t.IndexTemplateRegistry] [node-1] adding index template [.ml-anomalies-] for [ml], because it doesn't exist
[2020-07-08T23:36:28,816][INFO ][o.e.x.c.t.IndexTemplateRegistry] [node-1] adding index template [.ml-state] for [ml], because it doesn't exist
[2020-07-08T23:36:28,817][INFO ][o.e.x.c.t.IndexTemplateRegistry] [node-1] adding index template [.ml-config] for [ml], because it doesn't exist
[2020-07-08T23:36:28,817][INFO ][o.e.x.c.t.IndexTemplateRegistry] [node-1] adding index template [.ml-inference-000002] for [ml], because it doesn't exist
[2020-07-08T23:36:28,818][INFO ][o.e.x.c.t.IndexTemplateRegistry] [node-1] adding index template [.ml-meta] for [ml], because it doesn't exist
[2020-07-08T23:36:28,829][INFO ][o.e.x.c.t.IndexTemplateRegistry] [node-1] adding index template [.ml-notifications-000001] for [ml], because it doesn't exist
[2020-07-08T23:36:28,829][INFO ][o.e.x.c.t.IndexTemplateRegistry] [node-1] adding index template [.ml-stats] for [ml], because it doesn't exist
[2020-07-08T23:36:28,839][INFO ][o.e.x.c.t.IndexTemplateRegistry] [node-1] adding index template [ilm-history] for [index_lifecycle], because it doesn't exist
[2020-07-08T23:36:28,841][INFO ][o.e.x.c.t.IndexTemplateRegistry] [node-1] adding index template [.slm-history] for [index_lifecycle], because it doesn't exist
[2020-07-08T23:36:28,897][INFO ][o.e.g.GatewayService     ] [node-1] recovered [0] indices into cluster_state
[2020-07-08T23:36:29,346][INFO ][o.e.c.m.MetadataIndexTemplateService] [node-1] adding template [.watch-history-11] for index patterns [.watcher-history-11*]
[2020-07-08T23:36:29,389][INFO ][o.e.c.m.MetadataIndexTemplateService] [node-1] adding template [.watches] for index patterns [.watches*]
[2020-07-08T23:36:29,431][INFO ][o.e.c.m.MetadataIndexTemplateService] [node-1] adding template [.triggered_watches] for index patterns [.triggered_watches*]
[2020-07-08T23:36:29,468][INFO ][o.e.c.m.MetadataIndexTemplateService] [node-1] adding template [.ml-state] for index patterns [.ml-state*]
[2020-07-08T23:36:29,525][INFO ][o.e.c.m.MetadataIndexTemplateService] [node-1] adding template [.ml-anomalies-] for index patterns [.ml-anomalies-*]
[2020-07-08T23:36:29,569][INFO ][o.e.c.m.MetadataIndexTemplateService] [node-1] adding template [.ml-notifications-000001] for index patterns [.ml-notifications-000001]
[2020-07-08T23:36:29,602][INFO ][o.e.c.m.MetadataIndexTemplateService] [node-1] adding template [.ml-meta] for index patterns [.ml-meta]
[2020-07-08T23:36:29,641][INFO ][o.e.c.m.MetadataIndexTemplateService] [node-1] adding template [.ml-stats] for index patterns [.ml-stats-*]
[2020-07-08T23:36:29,680][INFO ][o.e.c.m.MetadataIndexTemplateService] [node-1] adding template [.ml-inference-000002] for index patterns [.ml-inference-000002]
[2020-07-08T23:36:29,725][INFO ][o.e.c.m.MetadataIndexTemplateService] [node-1] adding template [.ml-config] for index patterns [.ml-config]
[2020-07-08T23:36:29,779][INFO ][o.e.c.m.MetadataIndexTemplateService] [node-1] adding template [ilm-history] for index patterns [ilm-history-2*]
[2020-07-08T23:36:29,817][INFO ][o.e.c.m.MetadataIndexTemplateService] [node-1] adding template [.slm-history] for index patterns [.slm-history-2*]
[2020-07-08T23:36:29,867][INFO ][o.e.c.m.MetadataIndexTemplateService] [node-1] adding template [.monitoring-logstash] for index patterns [.monitoring-logstash-7-*]
[2020-07-08T23:36:29,919][INFO ][o.e.c.m.MetadataIndexTemplateService] [node-1] adding template [.monitoring-es] for index patterns [.monitoring-es-7-*]
[2020-07-08T23:36:29,970][INFO ][o.e.c.m.MetadataIndexTemplateService] [node-1] adding template [.monitoring-beats] for index patterns [.monitoring-beats-7-*]
[2020-07-08T23:36:30,014][INFO ][o.e.c.m.MetadataIndexTemplateService] [node-1] adding template [.monitoring-alerts-7] for index patterns [.monitoring-alerts-7]
[2020-07-08T23:36:30,058][INFO ][o.e.c.m.MetadataIndexTemplateService] [node-1] adding template [.monitoring-kibana] for index patterns [.monitoring-kibana-7-*]
[2020-07-08T23:36:30,099][INFO ][o.e.x.i.a.TransportPutLifecycleAction] [node-1] adding index lifecycle policy [watch-history-ilm-policy]
[2020-07-08T23:36:30,162][INFO ][o.e.x.i.a.TransportPutLifecycleAction] [node-1] adding index lifecycle policy [ml-size-based-ilm-policy]
[2020-07-08T23:36:30,219][INFO ][o.e.x.i.a.TransportPutLifecycleAction] [node-1] adding index lifecycle policy [ilm-history-ilm-policy]
[2020-07-08T23:36:30,250][INFO ][o.e.x.i.a.TransportPutLifecycleAction] [node-1] adding index lifecycle policy [slm-history-ilm-policy]
[2020-07-08T23:36:30,364][INFO ][o.e.l.LicenseService     ] [node-1] license [b604e8c6-3435-4faf-b324-cc2f454759c8] mode [basic] - valid
[2020-07-08T23:36:30,368][INFO ][o.e.x.s.s.SecurityStatusChangeListener] [node-1] Active license is now [BASIC]; Security is disabled

```

This is the current setting that I've used for this PR. Let me know if you think any other changes are needed.