### PR TITLE
Only call ElasticSearch when mapping.json is populated

### DIFF
--- a/mindmeld/components/entity_resolver.py
+++ b/mindmeld/components/entity_resolver.py
@@ -79,10 +79,7 @@ class EntityResolver:
         num_canonical_entities = len(
             self._resource_loader.get_entity_map(self.type).get("entities", [])
         )
-        if num_canonical_entities == 0:
-            self._no_canonical_entities = True
-        else:
-            self._no_canonical_entities = False
+        self._no_canonical_entities = num_canonical_entities == 0
 
     @property
     def _es_index_name(self):

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -157,7 +157,9 @@ def test_load_system(
 ):
     """Tests loading a query with a system entity"""
     # We added a pm timestamp to bias duckling time resolution to resolve to pm times
-    processed_query = markup.load_query(query, query_factory, query_options={'timestamp': 1592002800})
+    processed_query = markup.load_query(
+        query, query_factory, query_options={"timestamp": 1592002800}
+    )
 
     assert processed_query
     assert len(processed_query.entities) == 1


### PR DESCRIPTION
Some developers who are not using the Entity Resolution functionality of MindMeld don't want to get ElasticSearch set up. If an entity exists, ES is by default called, which can be confusing to those who only want to use the Entity Recognition component.

This change checks to see if the mapping.json file is empty when initializing the resolver. If it is, it doesn't make calls to ElasticSearch.