### PR TITLE
don't try to load a system entity emap

### DIFF
--- a/mindmeld/components/entity_resolver.py
+++ b/mindmeld/components/entity_resolver.py
@@ -80,7 +80,7 @@ class EntityResolver:
             canonical_entities = []
         else:
             canonical_entities = self._resource_loader.get_entity_map(self.type).get("entities", [])
-        self._no_canonical_entities = len(canonical_entities) == 0
+        self._no_canonical_entity_map = len(canonical_entities) == 0
 
     @property
     def _es_index_name(self):
@@ -200,7 +200,7 @@ class EntityResolver:
             clean (bool): If ``True``, deletes and recreates the index from scratch instead of
                           updating the existing index with synonyms in the mapping.json.
         """
-        if self._is_system_entity or self._no_canonical_entities:
+        if self._no_canonical_entity_map:
             return
 
         if not self._use_text_rel:
@@ -339,7 +339,7 @@ class EntityResolver:
             # system entities are already resolved
             return [top_entity.value]
 
-        if self._no_canonical_entities:
+        if self._no_canonical_entity_map:
             return []
 
         if not self._use_text_rel:

--- a/mindmeld/components/entity_resolver.py
+++ b/mindmeld/components/entity_resolver.py
@@ -76,10 +76,11 @@ class EntityResolver:
         self._es_host = es_host
         self._es_config = {"client": es_client, "pid": os.getpid()}
 
-        num_canonical_entities = len(
-            self._resource_loader.get_entity_map(self.type).get("entities", [])
-        )
-        self._no_canonical_entities = num_canonical_entities == 0
+        if self._is_system_entity:
+            canonical_entities = []
+        else:
+            canonical_entities = self._resource_loader.get_entity_map(self.type).get("entities", [])
+        self._no_canonical_entities = len(canonical_entities) == 0
 
     @property
     def _es_index_name(self):


### PR DESCRIPTION
The entity resolver has been trying to count canonical entities for system entities, which generates a bunch of warnings. The end behavior is still correct, since the code doesn't actually depend on the no_canonical_entities property for system entities. It just is doing extra file io and generating logs.
```
Entity data file not found at '/.../entities/sys_duration/gazetteer.txt'. Proceeding with empty entity data.
Entity mapping file not found at '/.../entities/sys_duration/mapping.json'. Proceeding with empty entity data.
Entity map file not found at /.../entities/sys_duration/mapping.json
```