### PR TITLE
Limit max history

### DIFF
--- a/mindmeld/app_manager.py
+++ b/mindmeld/app_manager.py
@@ -106,6 +106,7 @@ class ApplicationManager:
         self.dialogue_manager = DialogueManager(
             self.responder_class, async_mode=self.async_mode
         )
+        self.max_history_len = get_max_history_len(self._app_path) or self.MAX_HISTORY_LEN
 
     @property
     def ready(self):
@@ -286,8 +287,7 @@ class ApplicationManager:
 
         # limit length of history
         new_history = (prev_request,) + request.history
-        max_history_len = get_max_history_len(self._app_path) or self.MAX_HISTORY_LEN
-        dm_response.history = new_history[: max_history_len]
+        dm_response.history = new_history[: self.max_history_len]
 
         # validate outgoing params
         dm_response.params.validate_param("allowed_intents")

--- a/mindmeld/app_manager.py
+++ b/mindmeld/app_manager.py
@@ -17,6 +17,7 @@ This module contains the application manager
 import logging
 
 from .components import DialogueManager, NaturalLanguageProcessor, QuestionAnswerer
+from .components._config import get_max_history_len
 from .components.dialogue import DialogueResponder
 from .components.request import FrozenParams, Params, Request
 from .resource_loader import ResourceLoader
@@ -65,7 +66,7 @@ class ApplicationManager:
             dialogue_manager (DialogueManager): The application's dialogue manager.
     """
 
-    MAX_HISTORY_LEN = 100
+    MAX_HISTORY_LEN = 10
     """The max number of turns in history."""
 
     def __init__(
@@ -285,7 +286,8 @@ class ApplicationManager:
 
         # limit length of history
         new_history = (prev_request,) + request.history
-        dm_response.history = new_history[: self.MAX_HISTORY_LEN]
+        max_history_len = get_max_history_len(self._app_path) or self.MAX_HISTORY_LEN
+        dm_response.history = new_history[: max_history_len]
 
         # validate outgoing params
         dm_response.params.validate_param("allowed_intents")

--- a/mindmeld/components/_config.py
+++ b/mindmeld/components/_config.py
@@ -469,7 +469,20 @@ def get_custom_action_config(app_path):
         )
         return custom_action_config
     except (OSError, IOError):
-        logger.error("No app configuration file found.")
+        logger.info("No app configuration file found.")
+        return None
+
+
+def get_max_history_len(app_path):
+    if not app_path:
+        return None
+    try:
+        custom_action_config = getattr(
+            _get_config_module(app_path), "MAX_HISTORY_LEN", None
+        )
+        return custom_action_config
+    except (OSError, IOError):
+        logger.info("No app configuration file found.")
         return None
 
 

--- a/tests/components/test_config.py
+++ b/tests/components/test_config.py
@@ -15,6 +15,7 @@ from mindmeld.components._config import (
     _expand_parser_config,
     get_classifier_config,
     get_custom_action_config,
+    get_max_history_len,
 )
 
 APP_PATH = os.path.dirname(os.path.abspath(__file__))
@@ -154,3 +155,9 @@ def test_custom_action_config_no_config(home_assistant_app_path):
     actual = get_custom_action_config(home_assistant_app_path)
 
     assert actual is None
+
+
+def test_max_history_len_config(food_ordering_app_path):
+    actual = get_max_history_len(food_ordering_app_path)
+
+    assert actual == 5

--- a/tests/food_ordering/config.py
+++ b/tests/food_ordering/config.py
@@ -41,3 +41,5 @@ DOMAIN_MODEL_CONFIG = {
         "average-token-length": {},  # Custom feature
     },
 }
+
+MAX_HISTORY_LEN = 5


### PR DESCRIPTION
Change requested by @serapio who observed that serializing the history can take a lot of time

1. Reduce the default max history to 10 from 100
2. Enable app to configure max history from the app configuration