### PR TITLE
Adding support for custom resolution in custom eval function

### DIFF
--- a/mindmeld/components/dialogue.py
+++ b/mindmeld/components/dialogue.py
@@ -872,7 +872,7 @@ class AutoEntityFilling:
             # value is returned, then the validation succeeds.
 
             _validity = slot.custom_eval(request)
-            if not _validity:
+            if _validity is False:
                 # For checking 'false' return cases
                 return False, _resolved_value
       

--- a/mindmeld/components/dialogue.py
+++ b/mindmeld/components/dialogue.py
@@ -866,13 +866,21 @@ class AutoEntityFilling:
                 return False, _resolved_value
 
         if slot.custom_eval:
-            # Custom validation using function provided by developer. Should return True/False
-            # for validation status. If true, then continue, else fail overall validation.
+            # Custom validation using function provided by developer.
+            # Should return True/False/Custom Resolution value for validation status.
+            # If false, overall validation fails. If either true or a custom resolved
+            # value is returned, then the validation succeeds.
 
-            if not slot.custom_eval(request):
+            _validity = slot.custom_eval(request)
+            if not _validity:
+                # For checking 'false' return cases
                 return False, _resolved_value
-            else:
-                extracted_feature.update({"custom_validated_entity": text})
+      
+            if _validity is not True:
+                # For cases with custom resolution value return
+                _resolved_value = [{"value": _validity}]
+        
+            extracted_feature.update({"custom_validated_entity": text})
 
         # return True iff user input results in extracted features (i.e. successfully validated)
         return len(extracted_feature) > 0, _resolved_value

--- a/mindmeld/components/dialogue.py
+++ b/mindmeld/components/dialogue.py
@@ -875,11 +875,16 @@ class AutoEntityFilling:
             if _validity is False:
                 # For checking 'false' return cases
                 return False, _resolved_value
-      
+
             if _validity is not True:
                 # For cases with custom resolution value return
-                _resolved_value = [{"value": _validity}]
-        
+                if entity_type in DEFAULT_SYS_ENTITIES:
+                    # for custom system entity resolution
+                    _resolved_value = [{"value": _validity}]
+                else:
+                    # for custom gazetteer entity resolution
+                    _resolved_value = [{"cname": _validity}]
+
             extracted_feature.update({"custom_validated_entity": text})
 
         # return True iff user input results in extracted features (i.e. successfully validated)

--- a/mindmeld/core.py
+++ b/mindmeld/core.py
@@ -761,8 +761,9 @@ class FormEntity:
         default_eval(bool, optional): Use system validation (default: True)
         hints(list, optional): Developer defined list of keywords to verify the
         user input against
-        custom_eval(func, optional): custom validation function (should return bool:
-        validated or not)
+        custom_eval(func, optional): custom validation function (should return either bool:
+        validated or not) or a custom resolved value for the entity. If custom resolved value
+        is returned, the slot response is considered to be valid.
     """
 
     def __init__(

--- a/source/userguide/dm.rst
+++ b/source/userguide/dm.rst
@@ -602,8 +602,7 @@ This decorator replaces the need to define the ``@app.handle`` decorator. MindMe
   - ``value`` (str, optional): The resolved value of the entity.
   - ``default_eval`` (bool, optional): Use system validation (default: True).
   - ``hints`` (list, optional): Developer defined list of keywords to verify the user input against.
-  - ``custom_eval`` (func, optional): Custom validation function (should return bool:
-    validated or not). For this function, the developer is provided with the current turn's ``request`` object.
+  - ``custom_eval`` (func, optional): Custom validation function (should return either bool: validated or not) or a custom resolved value for the entity. If custom resolved value is returned, the slot response is considered to be valid. For this validation function, the developer is provided with the current turn's ``request`` object.
 
 Once the slot filling is complete, the filled in entities can be access through ``request.entities`` in the same manner as any other handler.
 

--- a/tests/components/test_auto_fill.py
+++ b/tests/components/test_auto_fill.py
@@ -152,7 +152,7 @@ def test_auto_fill_invoke(kwik_e_mart_app):
 
 
 @pytest.mark.conversation
-def test_auto_fill_custom_validation_resolutioon(kwik_e_mart_app):
+def test_auto_fill_custom_validation_resolution(kwik_e_mart_app):
     """Tests slot-filling's custom validation with custom resolution"""
     app = kwik_e_mart_app
     request = Request(


### PR DESCRIPTION
This PR allows developers to take control of custom slot-entity resolution in the custom eval function for slot-filling. 

- For example a case in the Spanish blueprint where basic units of distance are not recognized by duckling, a statement such as "my height is 1 meter and 75 centimeters" becomes "yo tengo {1|sys_number} {metro|unit} y {75|sys_number} {centimetros|unit} de estatura". This requires multiple entities to make up one slot. It can be handled by the developer now in the custom validation function and a single/joint value returned for the slot as a 'custom resolved' value.

- Cases where there is some conversion required (such as weight between kilos and pounds), instead of doing so inside the handler later, this enables the flexibility to do so in the custom validation itself.

- retains the earlier custom validation logic entirely. Adds an update, documentation update and a corresponding unit test.