### PR TITLE
Direct import of joblib

### DIFF
--- a/mindmeld/gazetteer.py
+++ b/mindmeld/gazetteer.py
@@ -16,7 +16,7 @@ import logging
 import os
 from collections import defaultdict
 
-from sklearn.externals import joblib
+import joblib
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
You can now directly do a import joblib

See this for more details - scikit-optimize/scikit-optimize#776

https://github.com/cisco/mindmeld/issues/203