### PR TITLE
Initialize system_entity_recognizer attr for EntityLabelEncoder

### DIFF
--- a/mindmeld/models/model.py
+++ b/mindmeld/models/model.py
@@ -1295,6 +1295,9 @@ class EntityLabelEncoder(LabelEncoder):
             list: A list of decoded labels per query
         """
         # TODO: support decoding multiple queries at once
+        if not hasattr(self, "system_entity_recognizer"):
+            # app built with older version of MM (< 4.3) does not save label encoder with sys recognizer
+            self.system_entity_recognizer = SystemEntityRecognizer.get_instance()
         examples = kwargs["examples"]
         labels = [
             get_entities_from_tags(examples[idx], tags, self.system_entity_recognizer)


### PR DESCRIPTION
For applications already built with an older version of MM, the EntityLabelEncoder is not initialized with the system entity recognizer. This PR should address that.
https://github.com/cisco/mindmeld/issues/208