### PR TITLE
Fixing linting errors off master

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup_requirements = ["pytest-runner~=2.11", "setuptools>=36"]
 
 test_requirements = [
     "flake8==3.5.0",
-    "pylint==1.6.5",
+    "pylint~=2.5.3",
     "pytest==3.8.0",
     "pytest-cov==2.4.0",
     "pytest-asyncio==0.8.0",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 coverage==4.2
 flake8==3.5.0
-pylint>=2.3.1
+pylint~=2.5.3
 pytest>=5.4.0
 pytest-cov==2.4.0
 tox==2.6.0


### PR DESCRIPTION
Currently, master branch is seeing new linting errors, which is probably caused by pulling a newer version of the linters. Pinning the dependency for pylint.