### PR TITLE
Add py37 to workflows

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7]
+        python-version: [3.6, 3.7]
         mm-extras: ["true", "false"]
         es_version: [5.6.16, 6.8.10, 7.7.1]
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6]
+        python-version: [3.5, 3.6, 3.7]
         mm-extras: ["true", "false"]
         es_version: [5.6.16, 6.8.10, 7.7.1]
 
     steps:
     - uses: actions/checkout@v2
-  
+
     - uses: nyaruka/elasticsearch-action@v1
       with:
         elastic version: ${{ matrix.es_version }}
@@ -35,13 +35,13 @@ jobs:
         architecture: x64 # (x64 or x86) - defaults to x64
       env:
         MM_EXTRAS: ${{ matrix.mm-extras }}
-    
+
     - name: Install dependencies
       run: |
         ./scripts/py_dep_install.sh
       env:
         MM_EXTRAS: ${{ matrix.mm-extras }}
-        
+
     - name: Linting
       run: |
         ./lintme
@@ -54,7 +54,7 @@ jobs:
       uses: jakejarvis/wait-action@master
       with:
         time: '30s'
-    
+
     - name: Test with pytest
       run: |
         mkdir ~/test-reports


### PR DESCRIPTION
MindMeld currently supports Python 3.7 but it is not tested in our Github workflow. This addresses that oversight.