### PR TITLE
Add deprecation warnings for Python 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ MindMeld has been used for applications in dozens of different domains by some o
 
 ## Quick Start
 
-Assuming you have pip installed with Python 3.5, Python 3.6 or Python 3.7 and Elasticsearch running in the background:
+> :warning: Python 3.5 reached end of life on 13 Sept 2020. MindMeld will deprecate official support for Python 3.5 in the next release. 
+
+Assuming you have pip installed with Python 3.5 (deprecated), Python 3.6 or Python 3.7 and Elasticsearch running in the background:
 
 ```
 pip install mindmeld

--- a/mindmeld/cli.py
+++ b/mindmeld/cli.py
@@ -48,6 +48,15 @@ click.disable_unicode_literals_warning = True
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"], "auto_envvar_prefix": "MM"}
 
+# deprecation warning for python 3.5
+if sys.version[:3] == "3.5":
+    deprecation_msg = (
+        "DEPRECATION: Python 3.5 reached end of life on 13 Sept 2020. MindMeld will deprecate"
+        " official support for Python 3.5 in the next release. Please consider migrating"
+        " your application to Python 3.6 and above."
+    )
+    logger.warning(deprecation_msg)
+
 
 def _version_msg():
     """Returns the MindMeld version, location and Python powering it."""
@@ -426,11 +435,7 @@ def load_index(ctx, es_host, app_namespace, index_name, data_file, app_path):
 
     try:
         QuestionAnswerer.load_kb(
-            app_namespace,
-            index_name,
-            data_file,
-            es_host,
-            app_path=app_path,
+            app_namespace, index_name, data_file, es_host, app_path=app_path,
         )
     except (KnowledgeBaseConnectionError, KnowledgeBaseError) as ex:
         logger.error(ex.message)

--- a/mindmeld/cli.py
+++ b/mindmeld/cli.py
@@ -49,7 +49,7 @@ click.disable_unicode_literals_warning = True
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"], "auto_envvar_prefix": "MM"}
 
 # deprecation warning for python 3.5
-if sys.version[:3] == "3.5":
+if sys.version_info < (3, 6):
     deprecation_msg = (
         "DEPRECATION: Python 3.5 reached end of life on 13 Sept 2020. MindMeld will deprecate"
         " official support for Python 3.5 in the next release. Please consider migrating"

--- a/source/userguide/getting_started.rst
+++ b/source/userguide/getting_started.rst
@@ -5,7 +5,7 @@ These instructions explain how to install MindMeld on a Unix-based system and se
 
 .. note::
 
-  MindMeld requires Python 3.5, 3.6 or 3.7.
+  MindMeld requires Python 3.6 or 3.7.
 
 
 Install MindMeld


### PR DESCRIPTION
Python 3.5 reached the end of life on 13 Sept 2020. MindMeld will deprecate official support for Python 3.5 in the next release, so we are adding the deprecation warnings to this release.

https://github.com/cisco/mindmeld/issues/221