### PR TITLE
Restore MAX_HISTORY_LEN to 100 and update documentation

### DIFF
--- a/mindmeld/app_manager.py
+++ b/mindmeld/app_manager.py
@@ -66,7 +66,7 @@ class ApplicationManager:
             dialogue_manager (DialogueManager): The application's dialogue manager.
     """
 
-    MAX_HISTORY_LEN = 10
+    MAX_HISTORY_LEN = 100
     """The max number of turns in history."""
 
     def __init__(

--- a/source/userguide/dm.rst
+++ b/source/userguide/dm.rst
@@ -129,7 +129,7 @@ Dialogue state handlers take two arguments: ``request`` and ``responder``.
 |                                   | language processor                                                              |
 +-----------------------------------+---------------------------------------------------------------------------------+
 | :data:`history`                   | List of previous and current responder objects (de-serialized) upto the         |
-|                                   | current conversation                                                            |
+|                                   | current conversation, currently up to a maximum default of 100 turns.           |
 +-----------------------------------+---------------------------------------------------------------------------------+
 | :data:`text`                      | The query text, as passed in the request                                        |
 +-----------------------------------+---------------------------------------------------------------------------------+
@@ -150,6 +150,10 @@ Dialogue state handlers take two arguments: ``request`` and ``responder``.
 +-----------------------------------+---------------------------------------------------------------------------------+
 | :data:`nbest_aligned_entities`    | List of lists of aligned entities for each of the n-best transcripts            |
 +-----------------------------------+---------------------------------------------------------------------------------+
+
+.. note::
+   The developer can set the maximum number of turn to keep by setting the ``MAX_HISTORY_LEN`` field inside ``config.py``.
+
 
 ``params``
 ^^^^^^^^^^
@@ -205,7 +209,7 @@ The ``responder`` is a mutable object used to send actions, like templated natur
 | :data:`slots`         | A dictionary containing key, value pairs used to fill NLR responses            |
 +-----------------------+--------------------------------------------------------------------------------+
 | :data:`history`       | List of previous and current responder objects (de-serialized) upto the        |
-|                       | current conversation                                                           |
+|                       | current conversation, currently up to a maximum default of 100 turns.          |
 +-----------------------+--------------------------------------------------------------------------------+
 | :data:`request`       | A reference to the immutable request object for the current turn               |
 +-----------------------+--------------------------------------------------------------------------------+
@@ -216,6 +220,9 @@ The ``responder`` is a mutable object used to send actions, like templated natur
 |                       | methods described in the next table. WARNING: Do not directly modify this      |
 |                       | list, use the directive methods detailed below instead.                        |
 +-----------------------+--------------------------------------------------------------------------------+
+
+.. note::
+   The developer can set the maximum number of turn to keep by setting the ``MAX_HISTORY_LEN`` field inside ``config.py``.
 
 The table below details the ``responder`` methods to send actions, also termed ``directives``, back to the client. You can invoke more than one directive method in a handler, but note that they are executed on a first-in-first-out basis. Internally, the following methods append dictionary-type payloads to the ``directives`` attribute of the ``responder`` object.
 
@@ -774,11 +781,13 @@ Alternatively, the standalone call to this feature can be called independently o
 
 .. note::
    
-    * The order of entities provided in the ``entities`` list in the form is important as the slots will be prompted in that order. 
-    .. |br|
+    * The order of entities provided in the ``entities`` list in the form is important as the slots will be prompted in that order.
+
+.. note::
 
     * All entities that are required by the slot-filling form for an intent should be covered through example queries in the training files for that intent.
-    .. |br|    
+
+.. note::
    
     * For better training the entity recognizer corresponding to the slot-filling intent, a separate training file ``train_label_set`` covering examples of the entities to be captured by the form can be defined. You can find more details about defining this file and modifying the entity recognizer :ref:`here <entity_recognition>`. This also allows intent and domain classifiers to be trained independently of such queries and learn appropriate context.
 

--- a/source/userguide/dm.rst
+++ b/source/userguide/dm.rst
@@ -129,7 +129,7 @@ Dialogue state handlers take two arguments: ``request`` and ``responder``.
 |                                   | language processor                                                              |
 +-----------------------------------+---------------------------------------------------------------------------------+
 | :data:`history`                   | List of previous and current responder objects (de-serialized) upto the         |
-|                                   | current conversation, currently up to a maximum default of 100 turns.           |
+|                                   | current conversation, up to a maximum of 100 turns by default.           |
 +-----------------------------------+---------------------------------------------------------------------------------+
 | :data:`text`                      | The query text, as passed in the request                                        |
 +-----------------------------------+---------------------------------------------------------------------------------+
@@ -152,7 +152,7 @@ Dialogue state handlers take two arguments: ``request`` and ``responder``.
 +-----------------------------------+---------------------------------------------------------------------------------+
 
 .. note::
-   The developer can set the maximum number of turn to keep by setting the ``MAX_HISTORY_LEN`` field inside ``config.py``.
+   The developer can set the maximum number of turns to keep by setting the ``MAX_HISTORY_LEN`` field inside ``config.py``.
 
 
 ``params``
@@ -209,7 +209,7 @@ The ``responder`` is a mutable object used to send actions, like templated natur
 | :data:`slots`         | A dictionary containing key, value pairs used to fill NLR responses            |
 +-----------------------+--------------------------------------------------------------------------------+
 | :data:`history`       | List of previous and current responder objects (de-serialized) upto the        |
-|                       | current conversation, currently up to a maximum default of 100 turns.          |
+|                       | current conversation, currently up to a maximum of 100 turns by default.          |
 +-----------------------+--------------------------------------------------------------------------------+
 | :data:`request`       | A reference to the immutable request object for the current turn               |
 +-----------------------+--------------------------------------------------------------------------------+
@@ -222,7 +222,7 @@ The ``responder`` is a mutable object used to send actions, like templated natur
 +-----------------------+--------------------------------------------------------------------------------+
 
 .. note::
-   The developer can set the maximum number of turn to keep by setting the ``MAX_HISTORY_LEN`` field inside ``config.py``.
+   The developer can set the maximum number of turns to keep by setting the ``MAX_HISTORY_LEN`` field inside ``config.py``.
 
 The table below details the ``responder`` methods to send actions, also termed ``directives``, back to the client. You can invoke more than one directive method in a handler, but note that they are executed on a first-in-first-out basis. Internally, the following methods append dictionary-type payloads to the ``directives`` attribute of the ``responder`` object.
 

--- a/source/userguide/dm.rst
+++ b/source/userguide/dm.rst
@@ -129,7 +129,7 @@ Dialogue state handlers take two arguments: ``request`` and ``responder``.
 |                                   | language processor                                                              |
 +-----------------------------------+---------------------------------------------------------------------------------+
 | :data:`history`                   | List of previous and current responder objects (de-serialized) upto the         |
-|                                   | current conversation, up to a maximum of 100 turns by default.           |
+|                                   | current conversation, up to a maximum of 100 turns by default.                  |
 +-----------------------------------+---------------------------------------------------------------------------------+
 | :data:`text`                      | The query text, as passed in the request                                        |
 +-----------------------------------+---------------------------------------------------------------------------------+
@@ -209,7 +209,7 @@ The ``responder`` is a mutable object used to send actions, like templated natur
 | :data:`slots`         | A dictionary containing key, value pairs used to fill NLR responses            |
 +-----------------------+--------------------------------------------------------------------------------+
 | :data:`history`       | List of previous and current responder objects (de-serialized) upto the        |
-|                       | current conversation, currently up to a maximum of 100 turns by default.          |
+|                       | current conversation, currently up to a maximum of 100 turns by default.       |
 +-----------------------+--------------------------------------------------------------------------------+
 | :data:`request`       | A reference to the immutable request object for the current turn               |
 +-----------------------+--------------------------------------------------------------------------------+
@@ -601,7 +601,7 @@ This decorator replaces the need to define the ``@app.handle`` decorator. MindMe
    <br />
 
 - ``FormEntity`` is a class that allows creation of entity objects for slot filling and comprises of the following attributes:
-  
+
   - ``entity`` (str, required): Entity name.
   - ``role`` (str, optional): The role of the entity.
   - ``responses`` (list or str, optional): Message for prompting the user for missing entities.
@@ -641,7 +641,7 @@ For the use case of transferring money in a banking assistant application, the f
             FormEntity(
                 entity='sys_amount-of-money',
                 responses=['And, how much do you want to transfer?'],
-                custom_eval=test_for_money # validates the user-response for this entity 
+                custom_eval=test_for_money # validates the user-response for this entity
                 ),                         # using this custom developer-defined function
                                            # checking for '$' sign.
             ],
@@ -705,7 +705,7 @@ Let's consider the previous example. Now, instead of a single pass form to captu
                 ),
             FormEntity(
                 entity='sys_amount-of-money',
-                responses=['And, how much do you want to transfer?'], 
+                responses=['And, how much do you want to transfer?'],
                 ),
             ],
         'max_retries': 1,
@@ -780,7 +780,7 @@ Alternatively, the standalone call to this feature can be called independently o
                     )
 
 .. note::
-   
+
     * The order of entities provided in the ``entities`` list in the form is important as the slots will be prompted in that order.
 
 .. note::
@@ -788,7 +788,7 @@ Alternatively, the standalone call to this feature can be called independently o
     * All entities that are required by the slot-filling form for an intent should be covered through example queries in the training files for that intent.
 
 .. note::
-   
+
     * For better training the entity recognizer corresponding to the slot-filling intent, a separate training file ``train_label_set`` covering examples of the entities to be captured by the form can be defined. You can find more details about defining this file and modifying the entity recognizer :ref:`here <entity_recognition>`. This also allows intent and domain classifiers to be trained independently of such queries and learn appropriate context.
 
 


### PR DESCRIPTION
After discussing with Vijay and Karthik, we decided to restore MAX_HISTORY_LEN to 100 since setting to 10 might break some apps. I have also added some documentation about setting MAX_HISTORY_LEN in ``config.py``