### PR TITLE
Update slot-filling docs

### DIFF
--- a/source/userguide/dm.rst
+++ b/source/userguide/dm.rst
@@ -606,7 +606,7 @@ This decorator replaces the need to define the ``@app.handle`` decorator. MindMe
   - ``role`` (str, optional): The role of the entity.
   - ``responses`` (list or str, optional): Message for prompting the user for missing entities.
   - ``retry_response`` (list or str, optional): Message for re-prompting users. If not provided, defaults to ``responses``.
-  - ``value`` (str, optional): The resolved value of the entity. (read note below for maintaining this value in a session).
+  - ``value`` (str, optional): The resolved value of the entity. (read :ref:`note <session_note>` for maintaining this value in a session).
   - ``default_eval`` (bool, optional): Use system validation (default: True).
   - ``hints`` (list, optional): Developer defined list of keywords to verify the user input against.
   - ``custom_eval`` (func, optional): Custom validation function (should return either bool: validated or not) or a custom resolved value for the entity. If custom resolved value is returned, the slot response is considered to be valid. For this validation function, the developer is provided with the current turn's ``request`` object.
@@ -791,7 +791,9 @@ Alternatively, the standalone call to this feature can be called independently o
 
     * For better training the entity recognizer corresponding to the slot-filling intent, a separate training file ``train_label_set`` covering examples of the entities to be captured by the form can be defined. You can find more details about defining this file and modifying the entity recognizer :ref:`here <entity_recognition>`. This also allows intent and domain classifiers to be trained independently of such queries and learn appropriate context.
 
-    * When using the slot-filling flow repeatedly, the form is reset in every turn. In order to maintain values in the form across a session with multiple calls to this flow, the ``value`` attribute in the ``FormEntity`` object for the slot can be updated with a pre-defined value or a user-input value at an initial iteration of the form.
+    .. _session_note:
+
+    * **Maintaining slot values in a session:** When using the slot-filling flow repeatedly, the form is reset in every turn. In order to maintain values in the form across a session with multiple calls to this flow, the ``value`` attribute in the ``FormEntity`` object for the slot can be updated with a pre-defined value or a user-input value at an initial iteration of the form.
 
 
 .. _dialogue_middleware:

--- a/source/userguide/dm.rst
+++ b/source/userguide/dm.rst
@@ -606,7 +606,7 @@ This decorator replaces the need to define the ``@app.handle`` decorator. MindMe
   - ``role`` (str, optional): The role of the entity.
   - ``responses`` (list or str, optional): Message for prompting the user for missing entities.
   - ``retry_response`` (list or str, optional): Message for re-prompting users. If not provided, defaults to ``responses``.
-  - ``value`` (str, optional): The resolved value of the entity.
+  - ``value`` (str, optional): The resolved value of the entity. (read note below for maintaining this value in a session).
   - ``default_eval`` (bool, optional): Use system validation (default: True).
   - ``hints`` (list, optional): Developer defined list of keywords to verify the user input against.
   - ``custom_eval`` (func, optional): Custom validation function (should return either bool: validated or not) or a custom resolved value for the entity. If custom resolved value is returned, the slot response is considered to be valid. For this validation function, the developer is provided with the current turn's ``request`` object.
@@ -790,6 +790,8 @@ Alternatively, the standalone call to this feature can be called independently o
 .. note::
 
     * For better training the entity recognizer corresponding to the slot-filling intent, a separate training file ``train_label_set`` covering examples of the entities to be captured by the form can be defined. You can find more details about defining this file and modifying the entity recognizer :ref:`here <entity_recognition>`. This also allows intent and domain classifiers to be trained independently of such queries and learn appropriate context.
+
+    * When using the slot-filling flow repeatedly, the form is reset in every turn. In order to maintain values in the form across a session with multiple calls to this flow, the ``value`` attribute in the ``FormEntity`` object for the slot can be updated with a pre-defined value or a user-input value at an initial iteration of the form.
 
 
 .. _dialogue_middleware:

--- a/source/userguide/dm.rst
+++ b/source/userguide/dm.rst
@@ -606,7 +606,7 @@ This decorator replaces the need to define the ``@app.handle`` decorator. MindMe
   - ``role`` (str, optional): The role of the entity.
   - ``responses`` (list or str, optional): Message for prompting the user for missing entities.
   - ``retry_response`` (list or str, optional): Message for re-prompting users. If not provided, defaults to ``responses``.
-  - ``value`` (str, optional): The resolved value of the entity. (read :ref:`note <session_note>` for maintaining this value in a session).
+  - ``value`` (str, optional): The resolved value of the entity. (Read :ref:`note <session_note>` for maintaining this value in the same session.)
   - ``default_eval`` (bool, optional): Use system validation (default: True).
   - ``hints`` (list, optional): Developer defined list of keywords to verify the user input against.
   - ``custom_eval`` (func, optional): Custom validation function (should return either bool: validated or not) or a custom resolved value for the entity. If custom resolved value is returned, the slot response is considered to be valid. For this validation function, the developer is provided with the current turn's ``request`` object.
@@ -779,6 +779,33 @@ Alternatively, the standalone call to this feature can be called independently o
                         "Your {account} account balance is ${amount:.2f}"
                     )
 
+.. _session_note:
+
+Maintaining slot values in a session
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+When using the slot-filling flow repeatedly, the form is reset in every turn. In order to maintain values in the form across a session with multiple calls to this flow, the ``value`` attribute in the ``FormEntity`` object for the slot can be updated with a pre-defined value or a user-input value at an initial iteration of the form. As an example, if the user asks for their balance of a particular account type, the ``value`` attribute can be populated with this response. Henceforth for all balance check inquiries by the user the app will show details for the same account without reprompting:
+
+.. code:: python
+
+  balance_form = {
+    'entities': [
+        FormEntity(
+            entity="account_type",
+            responses=["Sure. For which account - checkings, savings, or credit?"],
+            )
+        ],
+    'max_retries': 1,
+    'exit_keys': ['cancel', 'quit', 'exit'],
+    'exit_msg': "Sorry I cannot help you. Please try again."
+    }
+
+  @app.auto_fill(intent="check_balances", form=balance_form)
+  def check_balance(request, responder):
+      for entity in request.entities:
+            if entity["type"] == "account_type":
+                balance_form['entities'][0].value = entity["value"][0]["cname"]
+      ...
+
 .. note::
 
     * The order of entities provided in the ``entities`` list in the form is important as the slots will be prompted in that order.
@@ -790,10 +817,6 @@ Alternatively, the standalone call to this feature can be called independently o
 .. note::
 
     * For better training the entity recognizer corresponding to the slot-filling intent, a separate training file ``train_label_set`` covering examples of the entities to be captured by the form can be defined. You can find more details about defining this file and modifying the entity recognizer :ref:`here <entity_recognition>`. This also allows intent and domain classifiers to be trained independently of such queries and learn appropriate context.
-
-    .. _session_note:
-
-    * **Maintaining slot values in a session:** When using the slot-filling flow repeatedly, the form is reset in every turn. In order to maintain values in the form across a session with multiple calls to this flow, the ``value`` attribute in the ``FormEntity`` object for the slot can be updated with a pre-defined value or a user-input value at an initial iteration of the form.
 
 
 .. _dialogue_middleware:


### PR DESCRIPTION
Adds a note about pre-populating the slot value to use the form repeatedly in a session without any re-prompts of the slot.