### PR TITLE
Fix CapWords MindMeld

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,5 +68,5 @@ target/
 # duckling
 mindmeld/resources/duckling-*
 
-# Mindmeld Generated Data
+# MindMeld Generated Data
 mindmeld/data/

--- a/mindmeld-ui/README.md
+++ b/mindmeld-ui/README.md
@@ -1,4 +1,4 @@
-# Mindmeld UI
+# MindMeld UI
 
 This is a React application that can be run along with any of the blueprints, or any `mindmeld` based app.
 
@@ -47,7 +47,7 @@ REACT_APP_MINDMELD_URL = <MINDMELD_URL> # Set this if you need to point the UI t
 ```
 
 ### 4. Navigate the app
-First, you will need to run the Mindmeld app. If you are developing locally, you can do:
+First, you will need to run the MindMeld app. If you are developing locally, you can do:
 
 ```
 python -m [app-name] run`

--- a/mindmeld-ui/public/index.html
+++ b/mindmeld-ui/public/index.html
@@ -11,7 +11,7 @@
 
   <link href="https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,700|Open+Sans:300,700" rel="stylesheet">
 
-  <title>Mindmeld UI</title>
+  <title>MindMeld UI</title>
 </head>
 <body><div class="app" id="app"></div></body>
 </html>

--- a/mindmeld-ui/public/manifest.json
+++ b/mindmeld-ui/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "Mindmeld UI",
-  "name": "Mindmeld UI",
+  "short_name": "MindMeld UI",
+  "name": "MindMeld UI",
   "icons": [
     {
       "src": "favicon.ico",

--- a/mindmeld/converter/README.md
+++ b/mindmeld/converter/README.md
@@ -1,4 +1,4 @@
-### Mindmeld Conversion Tool
+### MindMeld Conversion Tool
 
 __Introduction__  
 This tool is designed to help make the migration from other conversational AI platforms to MindMeld as seamless as possible. MindMeld has many advantages that make it an ideal solution for building conversational assistants, and with this tool you can easily transfer your existing projects into MindMeld to expand their capabilities. Currently, we offer support for projects built in Rasa and Dialogflow.
@@ -23,11 +23,11 @@ __Limitations__
 *Rasa Users:*  
 - Rasa has the ability to have custom actions, which is not supported by
 the converter.
-- Rasa has the ability to handle multiple intents per query, while Mindmeld
+- Rasa has the ability to handle multiple intents per query, while MindMeld
 does not.
 - Rasa training data may be json format, which is not currently supported.
 - Rasa has a feature called Rasa forms which is not currently supported.
-- Rasa's configuration files are not transfered, instead generic Mindmeld
+- Rasa's configuration files are not transfered, instead generic MindMeld
 configuration files are copied over.
 
 *Dialogflow Users:*

--- a/mindmeld/converter/code_generator.py
+++ b/mindmeld/converter/code_generator.py
@@ -26,7 +26,7 @@ class CodeGenerator:
 
 class MindmeldCodeGenerator(CodeGenerator):
     """
-    This class generates Mindmeld specific python code blocks
+    This class generates MindMeld-specific python code blocks
     """
 
     def generate_handle(self, params):

--- a/mindmeld/converter/dialogflow.py
+++ b/mindmeld/converter/dialogflow.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 """This module contains the DialogflowConverter class used to convert Dialogflow projects
-into Mindmeld projects"""
+into MindMeld projects"""
 
 import json
 import logging
@@ -507,7 +507,7 @@ class DialogflowConverter(Converter):
         implement this. The converter is able to successfully convert dialogflow
         bots that support multiple languages.
 
-        Mindmeld:
+        MindMeld:
         - Users can store data locally
         - Users can build a knowledge base (currently beta in Dialogflow).
         - Users can configure the machine learning models to best suit their needs.
@@ -520,7 +520,7 @@ class DialogflowConverter(Converter):
         # Create project directory with sub folders
         self.create_mindmeld_directory()
 
-        # copy config file to the Mindmeld dir
+        # copy config file to the MindMeld dir
         if self.custom_config_file_path:
             copyfile(
                 self.custom_config_file_path,
@@ -531,6 +531,6 @@ class DialogflowConverter(Converter):
         self.create_main(self.mindmeld_project_directory, file_loc)
         self.create_mindmeld_init()
 
-        # Transfer over test data from Dialogflow project and reformat to Mindmeld project
+        # Transfer over test data from Dialogflow project and reformat to MindMeld project
         self.create_mindmeld_training_data()
         logger.info("Project converted.")

--- a/mindmeld/converter/rasa.py
+++ b/mindmeld/converter/rasa.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 """This module contains the Rasacoverter class used to convert Rasa projects
-into Mindmeld projects"""
+into MindMeld projects"""
 
 import copy
 import logging
@@ -583,10 +583,10 @@ __all__ = ['app']
             f.write(string)
 
     def convert_project(self):
-        """Main function that will convert a Rasa project into a Mindmeld project.
+        """Main function that will convert a Rasa project into a MindMeld project.
 
         The Rasa project consists of three major files that contain much of data
-            that is converted into the Mindmeld project:
+            that is converted into the MindMeld project:
         /domain.yml - Contains all of the intents, entities, actions, and templates
             used in the rasa project
         /data/stories.md - Contains the stories which are used to match intents and
@@ -595,16 +595,16 @@ __all__ = ['app']
             training data may contain entities
 
         limitations:
-        - Rasa has the ability to handle multiple intents per query, while Mindmeld
+        - Rasa has the ability to handle multiple intents per query, while MindMeld
         does not.
         - Rasa training data may be json format, which is not currently supported.
         - Rasa has a feature called Rasa forms which is not currently supported.
-        - Rasa's configuration files are not transfered, instead generic Mindmeld
+        - Rasa's configuration files are not transfered, instead generic MindMeld
         configuration files are copied over.
         """
         # Create project directory with sub folders
         self.create_mindmeld_directory(self.mindmeld_project_directory)
-        # Transfer over test data from Rasa project and reformat to Mindmeld project
+        # Transfer over test data from Rasa project and reformat to MindMeld project
         self.create_mindmeld_training_data()
         file_loc = os.path.dirname(os.path.realpath(__file__))
         self.create_main(self.mindmeld_project_directory, file_loc)

--- a/source/blueprints/hr_assistant.rst
+++ b/source/blueprints/hr_assistant.rst
@@ -160,7 +160,7 @@ Let's begin by looking at some of the dialogue states for the intents in the ``g
 
           ...
 
-Observe that the same intent has multiple dialogue states that specify a ``has_entity`` field, except for the last case which serves as the default case. In other words, Mindmeld will feed the request to the dialogue state handler if there is a match between an entity found in the user query and the entity that the dialogue state handler accepts. If none of the entities are found, Mindmeld will default to the last case that does not specify an entity. This is where the system can follow up with the user and ask for any information needed to complete the query.
+Observe that the same intent has multiple dialogue states that specify a ``has_entity`` field, except for the last case which serves as the default case. In other words, MindMeld will feed the request to the dialogue state handler if there is a match between an entity found in the user query and the entity that the dialogue state handler accepts. If none of the entities are found, MindMeld will default to the last case that does not specify an entity. This is where the system can follow up with the user and ask for any information needed to complete the query.
 
 
 

--- a/source/blueprints/screening_app.rst
+++ b/source/blueprints/screening_app.rst
@@ -104,7 +104,7 @@ To support the functionality we envision, our app needs one dialogue state for e
 +---------------------------------------------------+-----------------------------------+------------------------------------------------------------------------------------------------------------------+
 | ``answer_gender``                                 | ``set_gender_send_next``          | Record the user's gender and respond with the next question                                                      |
 +---------------------------------------------------+-----------------------------------+------------------------------------------------------------------------------------------------------------------+
-| ``answer_yes``                                    | ``confirm_send_next``             | If the user accepts the screening with an explicit "yes", the behavior is the same as ``opt_in``.                | 
+| ``answer_yes``                                    | ``confirm_send_next``             | If the user accepts the screening with an explicit "yes", the behavior is the same as ``opt_in``.                |
 |                                                   |                                   | If the answer is for a screening question, record ``True`` for that question and respond with the next question. |
 +---------------------------------------------------+-----------------------------------+------------------------------------------------------------------------------------------------------------------+
 | ``answer_no``                                     | ``negate_send_next``              | If the user rejects the screening, exit the conversation. If the answer is for a screening question, record      |
@@ -132,44 +132,44 @@ Once a user has opted into the screening, a multi-turn dialogue begins where the
    @app.dialogue_flow(domain='prediabetes_screening', intent='opt_in')
    def screen_prediabetes(request, responder):
       ...
-      
+
    @screen_prediabetes.handle(intent='answer_age')
    def set_age_send_next(request, responder):
       ...
-      
+
    @screen_prediabetes.handle(intent='answer_gender')
    def set_gender_send_next(request, responder):
       ...
-      
+
    @screen_prediabetes.handle(intent='answer_yes_gestational')
    def confirm_gestational_send_next(request, responder):
       ...
-      
+
    @screen_prediabetes.handle(intent='answer_yes_family')
    def confirm_family_send_next(request, responder):
       ...
-      
+
    @screen_prediabetes.handle(intent='answer_yes_hbp')
    def confirm_hbp_send_next(request, responder):
       ...
-      
+
    @screen_prediabetes.handle(intent='answer_yes_active')
    def confirm_active_send_next(request, responder):
       ...
-      
+
    @screen_prediabetes.handle(intent='answer_height')
    def set_height_send_next(request, responder):
       ...
-      
+
    @screen_prediabetes.handle(intent='answer_weight')
    def set_weight_send_next(request, responder):
       ...
-      
+
    @app.handle(intent='answer_yes')
    @screen_prediabetes.handle(intent='answer_yes')
    def confirm_send_next(request, responder):
       ...
-      
+
    @app.handle(intent='answer_no')
    @screen_prediabetes.handle(intent='answer_no')
    def negate_send_next(request, responder):
@@ -221,11 +221,11 @@ The ``domains`` directory contains the training data for intent classification a
 Setting up language configuration
 """""""""""""""""""""""""""""""""
 
-Mindmeld supports `ISO 639-1 and ISO 639-2 language codes <https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes>`_ and
+MindMeld supports `ISO 639-1 and ISO 639-2 language codes <https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes>`_ and
 `ISO 3166-2 locale codes <https://www.iso.org/obp/ui/#search/code/>`_. Locale codes are represented as ISO 639-1 language code
 and ISO3166 alpha 2 country code separated by an underscore character, for example, `en_US`.
 
-For the app to use Spanish in Mindmeld, the ``config.py`` file needs to be configured as follows:
+For the app to use Spanish in MindMeld, the ``config.py`` file needs to be configured as follows:
 
 .. code-block:: console
 
@@ -234,7 +234,7 @@ For the app to use Spanish in Mindmeld, the ``config.py`` file needs to be confi
         'locale': 'es_MX'
     }
 
-Note that Mexico (MX) is set as the locale as a demonstration, but in the case of Spanish, all locales are treated the same. If the language and locale codes are not configured in ``config.py``, Mindmeld uses this default:
+Note that Mexico (MX) is set as the locale as a demonstration, but in the case of Spanish, all locales are treated the same. If the language and locale codes are not configured in ``config.py``, MindMeld uses this default:
 
 .. code-block:: console
 
@@ -243,7 +243,7 @@ Note that Mexico (MX) is set as the locale as a demonstration, but in the case o
         'locale': 'en_US'
     }
 
-Mindmeld supports most languages that can be tokenized like English. Apart from tokenization, there are two optional Mindmeld components, stemming and system entities, that only support a subset of languages. Stemming and system entities are both supported for Spanish.
+MindMeld supports most languages that can be tokenized like English. Apart from tokenization, there are two optional MindMeld components, stemming and system entities, that only support a subset of languages. Stemming and system entities are both supported for Spanish.
 
 .. code:: python
 
@@ -375,7 +375,7 @@ Start by inspecting the baseline configurations that the different classifiers u
 .. code-block:: console
 
    {
-      'bag-of-words': {'lengths': [1, 2]}, 
+      'bag-of-words': {'lengths': [1, 2]},
       'enable-stemming': True
    }
 

--- a/source/mindmeld_ui/mindmeld_ui.rst
+++ b/source/mindmeld_ui/mindmeld_ui.rst
@@ -55,7 +55,7 @@ At the `mindmeld-ui` directory, you can add a `.env` file that includes your con
 4. Navigate the app
 ^^^^^^^^^^^^^^^^^^^
 
-First, you will need to run the Mindmeld app. If you are developing locally, you can do:
+First, you will need to run the MindMeld app. If you are developing locally, you can do:
 
 .. code-block:: console
 

--- a/source/userguide/dvc.rst
+++ b/source/userguide/dvc.rst
@@ -1,15 +1,15 @@
 DVC for Model Tracking
 ======================
 
-We use Data Version Control, or DVC, in Mindmeld in order to track trained models in our applications. DVC is an
+We use Data Version Control, or DVC, in MindMeld in order to track trained models in our applications. DVC is an
 open-source version control system for data science and machine learning projects that enables versioning of large
 files and directories in concert with Git without storing the data itself in Git.
 
 You can find more info about DVC in the `official documentation <https://dvc.org/doc>`_.
 
-The functionality of the DVC command within Mindmeld is shown in the table below.
+The functionality of the DVC command within MindMeld is shown in the table below.
 
-Available Options in Mindmeld
+Available Options in MindMeld
 -----------------------------
 
 +-----------------+------------------------------------------------------------------------+

--- a/source/userguide/getting_started.rst
+++ b/source/userguide/getting_started.rst
@@ -390,7 +390,7 @@ Using the Python shell
 The :doc:`Step-By-Step guide <../quickstart/00_overview>` walks through the methodology for building conversational apps using MindMeld.
 
 
-Upgrade Mindmeld
+Upgrade MindMeld
 ----------------
 
 To upgrade to the latest version of MindMeld, run ``pip install mindmeld --upgrade``

--- a/source/userguide/internationalization.rst
+++ b/source/userguide/internationalization.rst
@@ -1,10 +1,10 @@
 Internationalization support
 ============================
 
-Mindmeld supports most languages that can be tokenized like English. If the language does not use spaces between
+MindMeld supports most languages that can be tokenized like English. If the language does not use spaces between
 words or has many non-English-like punctuation marks, pre-process the data to remove punctuations and add spaces between words.
 
-Apart from tokenization, there are two optional Mindmeld components, Stemming and System entity resolution, that only support a subset of languages.
+Apart from tokenization, there are two optional MindMeld components, Stemming and System entity resolution, that only support a subset of languages.
 The limitations of these two components are discussed below.
 
 .. _language_config:
@@ -12,11 +12,11 @@ The limitations of these two components are discussed below.
 Setting up language configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Mindmeld supports `ISO 639-1 and ISO 639-2 language codes <https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes>`_ and
+MindMeld supports `ISO 639-1 and ISO 639-2 language codes <https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes>`_ and
 `ISO 3166-2 locale codes <https://www.iso.org/obp/ui/#search/code/>`_. Locale codes are represented as ISO 639-1 language code
 and ISO3166 alpha 2 country code separated by an underscore character, for example, `en_US`.
 
-To use a particular language or locale in Mindmeld, the ``config.py`` file needs to configured as follows:
+To use a particular language or locale in MindMeld, the ``config.py`` file needs to configured as follows:
 
 .. code:: python
 
@@ -25,7 +25,7 @@ To use a particular language or locale in Mindmeld, the ``config.py`` file needs
         'locale': 'en_CA'
     }
 
-If the language and locale codes are not configured in ``config.py``, Mindmeld uses this default:
+If the language and locale codes are not configured in ``config.py``, MindMeld uses this default:
 
 .. code:: python
 
@@ -39,7 +39,7 @@ Language stemming
 ^^^^^^^^^^^^^^^^^
 
 Stemming is an important, language-dependent NLP process that transforms a word to an approximation of its root form. Stemming can be
-useful for some languages like English but not for others like Vietnamese. Mindmeld supports the following ISO 639-1 language codes for stemming:
+useful for some languages like English but not for others like Vietnamese. MindMeld supports the following ISO 639-1 language codes for stemming:
 [EN, DA, NL, AR, FR, DE, HU, IT, NO, PT, RU, RO, ES, SV, FI].
 
 System entity resolution


### PR DESCRIPTION
We have been a little inconsistent with MindMeld capitalization in documentation and elsewhere. This switches everything to the official CapWords form, except when it's specifically talking about the `mindmeld` package or other code.