### PR TITLE
Added es resolution build flag

### DIFF
--- a/mindmeld/components/entity_resolver.py
+++ b/mindmeld/components/entity_resolver.py
@@ -75,6 +75,7 @@ class EntityResolver:
         self._er_config = get_classifier_config("entity_resolution", app_path=app_path)
         self._es_host = es_host
         self._es_config = {"client": es_client, "pid": os.getpid()}
+        self.ready = False
 
         if self._is_system_entity:
             canonical_entities = []
@@ -202,6 +203,9 @@ class EntityResolver:
             clean (bool): If ``True``, deletes and recreates the index from scratch instead of
                           updating the existing index with synonyms in the mapping.json.
         """
+        if self.ready:
+            return
+
         if self._no_canonical_entity_map:
             return
 
@@ -270,6 +274,8 @@ class EntityResolver:
                 es_client=self._es_client,
                 use_double_metaphone=self._use_double_metaphone,
             )
+
+        self.ready = True
 
     @staticmethod
     def _process_entity_map(entity_type, entity_map, normalizer):

--- a/mindmeld/components/nlp.py
+++ b/mindmeld/components/nlp.py
@@ -427,6 +427,10 @@ class NaturalLanguageProcessor(Processor):
         self.progress_bar = progress_bar
 
         for domain in path.get_domains(self._app_path):
+
+            if domain in self._children:
+                continue
+
             self._children[domain] = DomainProcessor(
                 app_path, domain, self.resource_loader, self.progress_bar
             )
@@ -815,6 +819,10 @@ class DomainProcessor(Processor):
             self.progress_bar.total += 1
 
         for intent in intents:
+
+            if intent in self._children:
+                continue
+
             self._children[intent] = IntentProcessor(
                 app_path, domain, intent, self.resource_loader, progress_bar
             )
@@ -1100,6 +1108,10 @@ class IntentProcessor(Processor):
         # Create the entity processors
         entity_types = self.entity_recognizer.entity_types
         for entity_type in entity_types:
+
+            if entity_type in self._children:
+                return
+
             processor = EntityProcessor(
                 self._app_path,
                 self.domain,
@@ -1130,6 +1142,10 @@ class IntentProcessor(Processor):
         # Create the entity processors
         entity_types = self.entity_recognizer.entity_types
         for entity_type in entity_types:
+
+            if entity_type in self._children:
+                continue
+
             processor = EntityProcessor(
                 self._app_path,
                 self.domain,


### PR DESCRIPTION
This PR adds a flag to only run the entity resolver once every build. This insures that there aren't too many index construction calls to ES if `nlp.build` needs to be run multiple times. The limitation of this design is that if the entity maps change after `nlp.build` is done, the updated maps will not be ingest unless the user reinitializes the `nlp` object and runs build again.