### PR TITLE
Bug/timestamp validation

### DIFF
--- a/tests/components/test_schemas.py
+++ b/tests/components/test_schemas.py
@@ -1,0 +1,38 @@
+import pytest
+
+from mindmeld.components import schemas
+
+
+@pytest.mark.parametrize('value, expected', (
+        # str int in seconds
+        ('1600000000', 1600000000000),
+        # str int in ms
+        ('1600000000000', 1600000000000),
+        # str float in seconds
+        ('1600000000.000', 1600000000000),
+        # str float in seconds (preserve ms)
+        ('1600000000.123', 1600000000123),
+        # str float in seconds (preserve ms, round up)
+        ('1600000000.1239', 1600000000124),
+        # str float in ms
+        ('1600000000000.100', 1600000000000),
+        # str float in ms (round up)
+        ('1600000000000.900', 1600000000001),
+        # int in seconds
+        (1600000000, 1600000000000),
+        # int in ms
+        (1600000000000, 1600000000000),
+        # float in seconds
+        (1600000000.000, 1600000000000),
+        # float in seconds (preserve ms)
+        (1600000000.123, 1600000000123),
+        # float in seconds (preserve ms, round up)
+        (1600000000.1239, 1600000000124),
+        # float in ms
+        (1600000000000.100, 1600000000000),
+        # float in ms (round up)
+        (1600000000000.900, 1600000000001),
+    )
+)
+def test_validate_timestamp(value, expected):
+    assert schemas.validate_timestamp(value) == expected

--- a/tests/components/test_schemas.py
+++ b/tests/components/test_schemas.py
@@ -1,5 +1,7 @@
 import pytest
 
+from marshmallow import ValidationError
+
 from mindmeld.components import schemas
 
 
@@ -35,4 +37,18 @@ from mindmeld.components import schemas
     )
 )
 def test_validate_timestamp(value, expected):
+    """Tests for `validate_timestamp()`"""
     assert schemas.validate_timestamp(value) == expected
+
+
+@pytest.mark.parametrize('value', (
+    "asdf",
+    "1.341.123",
+    -1600000000,
+    0,
+    None,
+))
+def test_validate_timestamp_negative(value):
+    """Negative tests for `validate_timestamp()`"""
+    with pytest.raises(ValidationError):
+        schemas.validate_timestamp(value)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -106,13 +106,12 @@ def test_parse_endpoint_multiple_requests(client):
                     "locale": "en_US",
                     "target_dialogue_state": "transfer_money_handler",
                     "time_zone": '',
-                    "timestamp": 0
                 },
             },
             "Bad request {'text': 'hello', "
             "'params': {'allowed_intents': [], 'dynamic_resource': {}, "
             "'language': 'en', 'locale': 'en_US', 'target_dialogue_state': "
-            "'transfer_money_handler', 'time_zone': '', 'timestamp': 0}} caused "
+            "'transfer_money_handler', 'time_zone': ''}} caused "
             "error {'params': {'time_zone': ['Invalid time_zone param:  "
             "is not a valid time zone.']}}"
         ),


### PR DESCRIPTION
I noticed that MindMeld timestamp validation is not robust to passing in floats or string representations of floats. This fixes that and adds some tests so we should be covered.