### PR TITLE
Bugfix/Adds missing 'verbose' field to RequestSchema

### DIFF
--- a/mindmeld/components/schemas.py
+++ b/mindmeld/components/schemas.py
@@ -377,6 +377,7 @@ class RequestSchema(Schema):
     text = fields.String(required=True)
     domain = fields.String()
     intent = fields.String()
+    verbose = fields.Boolean()
     entities = fields.Method("serialize_entities",
                              deserialize="deserialize_list_of_maps")
     history = fields.Method("serialize_history",


### PR DESCRIPTION
This PR adds the missing 'verbose' attribute to the RequestSchema class. 

Current error, testing on the MindMeld server:
```
error: Bad request {'text': 'when is the movie being telecast', 'context': {}, 'frame': {}, 'history': [], 'params': {}, 'verbose': True} caused error {'verbose': ['Unknown field.’]}
```