### PR TITLE
Create a model registry with DVC and DAGsHub (P2)

### DIFF
--- a/mindmeld/cli.py
+++ b/mindmeld/cli.py
@@ -168,16 +168,27 @@ def _bash_helper(command_list):
 @_app_cli.command("dvc", context_settings=CONTEXT_SETTINGS)
 @click.pass_context
 @click.option(
-    "--init", is_flag=True, required=False, help="Instantiate DVC within a repository"
+    "--init",
+    is_flag=True,
+    required=False,
+    help="Instantiate DVC within a repository"
 )
 @click.option(
-    "--setup_dagshub", is_flag=True, required=False, help="Setup a central model registry with DAGsHub"
+    "--setup_dagshub",
+    is_flag=True,
+    required=False,
+    help="Setup a central model registry with DAGsHub"
 )
 @click.option(
-    "--save", is_flag=True, required=False, help="Save built models using dvc"
+    "--save",
+    is_flag=True,
+    required=False,
+    help="Save built models using dvc"
 )
 @click.option(
-    "--checkout", required=False, help="Checkout repo and models corresponding to git hash"
+    "--checkout",
+    required=False,
+    help="Checkout repo and models corresponding to git hash"
 )
 @click.option(
     "--help",
@@ -233,9 +244,14 @@ def dvc(ctx, init, setup_dagshub, save, checkout, help_, destroy):
         )
     elif setup_dagshub:
         click.clear()
-        click.secho('You will now set up a central model registry for you MindMeld project on DAGsHub.com',
-                    fg='blue', bg='white')
-        click.echo('====================================================================================')
+        click.secho(
+            'You will now set up a central model registry for you MindMeld project on DAGsHub.com',
+            fg='blue',
+            bg='white'
+        )
+        click.echo(
+            '===================================================================================='
+        )
         click.echo(
             '* If you don\'t have a DAGsHub account, sign up here <{0}>\n'
             '* After signing up, create a DAGsHub project by:\n'

--- a/mindmeld/cli.py
+++ b/mindmeld/cli.py
@@ -83,6 +83,7 @@ DVC_ADD_DOES_NOT_EXIST_HELP = "The folder {dvc_add_path} does not exist"
 DVC_COMMAND_HELP_MESSAGE = (
     "Options:"
     "\n\t--init\t\tInstantiate DVC within a repository"
+    "\n\t--setup-dagshub\t\tSetup a central model registry with DAGsHub"
     "\n\t--save\t\tSave built models using dvc"
     "\n\t--checkout HASH\tCheckout repo and models corresponding to git hash"
     "\n\t--destroy\tRemove all files associated with DVC from a directory"
@@ -170,9 +171,14 @@ def _bash_helper(command_list):
     "--init", is_flag=True, required=False, help="Instantiate DVC within a repository"
 )
 @click.option(
+    "--setup_dagshub", is_flag=True, required=False, help="Setup a central model registry with DAGsHub"
+)
+@click.option(
     "--save", is_flag=True, required=False, help="Save built models using dvc"
 )
-@click.option("--checkout", required=False, help="Instantiate DVC within a repository")
+@click.option(
+    "--checkout", required=False, help="Checkout repo and models corresponding to git hash"
+)
 @click.option(
     "--help",
     "help_",
@@ -186,7 +192,7 @@ def _bash_helper(command_list):
     required=False,
     help="Remove all files associated with dvc from directory",
 )
-def dvc(ctx, init, save, checkout, help_, destroy):
+def dvc(ctx, init, setup_dagshub, save, checkout, help_, destroy):
     app = ctx.obj.get("app")
     app_path = app.app_path
 
@@ -225,6 +231,78 @@ def dvc(ctx, init, save, checkout, help_, destroy):
         logger.info(
             "The newly generated dvc config file (.dvc/config) has been added to git staging"
         )
+    elif setup_dagshub:
+        click.clear()
+        click.secho('You will now set up a central model registry for you MindMeld project on DAGsHub.com',
+                    fg='blue', bg='white')
+        click.echo('====================================================================================')
+        click.echo(
+            '* If you don\'t have a DAGsHub account, sign up here <{0}>\n'
+            '* After signing up, create a DAGsHub project by:\n'
+            '    - Connecting an existing GitHub repository <{1}>, or\n'
+            '    - Create a new one from scratch <{2}>\n'.format(
+                click.style('https://dagshub.com/user/sign_up', fg='cyan'),
+                click.style('https://dagshub.com/repo/connect', fg='cyan'),
+                click.style('https://dagshub.com/repo/create', fg='cyan')
+            )
+        )
+        dagshub_remote_path = click.prompt('Please enter your DAGsHub project URL '
+                                           '(e.g. https://dagshub.com/username/projectname)')
+        dagshub_user = click.prompt('Please enter your DAGsHub username')
+        dagshub_password = click.prompt(
+            'Please enter your DAGsHub password or access token \n'
+            '(if you\'re not sure where to find it, go to <{0}>)'.format(
+                click.style('https://dagshub.com/user/settings/tokens', fg='cyan')
+            )
+        )
+
+        # Modify remote URL to be the DAGsHub project
+        success, error_string = _bash_helper(
+            ["dvc", "remote", "modify", "myremote", "url", dagshub_remote_path + '.dvc']
+        )
+        if not success:
+            logger.error("Error during DAGsHub remote set up: %s", error_string)
+            return
+
+        # Setup credentials for DAGsHub project
+        success, error_string = _bash_helper(
+            ["dvc", "remote", "modify", "myremote", "--local", "auth", "basic"]
+        )
+        if not success:
+            logger.error("Error during DAGsHub credential set up: %s", error_string)
+            return
+
+        success, error_string = _bash_helper(
+            ["dvc", "remote", "modify", "myremote", "--local", "user", dagshub_user]
+        )
+        if not success:
+            logger.error("Error during DAGsHub credential set up: %s", error_string)
+            return
+
+        success, error_string = _bash_helper(
+            ["dvc", "remote", "modify", "myremote", "--local", "password", dagshub_password]
+        )
+        if not success:
+            logger.error("Error during DAGsHub credential set up: %s", error_string)
+            return
+
+        # Add DVC config file to staging
+        success, error_string = _bash_helper(["git", "add", ".dvc/config"])
+        if not success:
+            logger.error("Error while adding dvc config file: %s", error_string)
+            return
+
+        logger.info(
+            "Set up DAGsHub central model repository in %s", dagshub_remote_path
+        )
+        logger.info(
+            "The updated dvc config file (.dvc/config) has been added to git staging"
+        )
+        logger.info(
+            "We recommend setting up your Git remote and pushing your code to it using "
+            "`git push` so that you can view your project in the DAGsHub UI."
+        )
+
     elif save:
         generated_model_folder = get_generated_data_folder(app_path)
 

--- a/mindmeld/cli.py
+++ b/mindmeld/cli.py
@@ -165,6 +165,7 @@ def _bash_helper(command_list):
     return True, None
 
 
+# pylint: disable=too-many-return-statements
 @_app_cli.command("dvc", context_settings=CONTEXT_SETTINGS)
 @click.pass_context
 @click.option(

--- a/mindmeld/components/entity_recognizer.py
+++ b/mindmeld/components/entity_recognizer.py
@@ -305,8 +305,8 @@ class EntityRecognizer(Classifier):
 
     def _get_examples_and_labels_hash(self, queries):
         hashable_queries = (
-            [self.domain + "###" + self.intent + "###entity###"] +
-            sorted(list(queries.raw_queries()))
+            [self.domain + "###" + self.intent + "###entity###"]
+            + sorted(list(queries.raw_queries()))
         )
         return self._resource_loader.hash_list(hashable_queries)
 

--- a/mindmeld/components/question_answerer.py
+++ b/mindmeld/components/question_answerer.py
@@ -107,8 +107,8 @@ class BaseQuestionAnswerer(ABC):
             kwargs.get("resource_loader") or ResourceLoader.create_resource_loader(self.app_path)
         )
         self._qa_config = (
-            kwargs.get("config") or
-            get_classifier_config("question_answering", app_path=self.app_path)
+            kwargs.get("config")
+            or get_classifier_config("question_answering", app_path=self.app_path)
         )
 
     def __repr__(self):
@@ -218,8 +218,8 @@ class BaseQuestionAnswerer(ABC):
         """
 
         if (
-            ("config" in kwargs and kwargs["config"]) or
-            ("app_path" in kwargs and kwargs["app_path"])
+            ("config" in kwargs and kwargs["config"])
+            or ("app_path" in kwargs and kwargs["app_path"])
         ):
             msg = "Passing 'config' or 'app_path' to '.load_kb()' method is no longer " \
                   "supported. Create a Question Answerer instance with the required " \
@@ -607,8 +607,8 @@ class NativeQuestionAnswerer(BaseQuestionAnswerer):
             elif isinstance(value, str) and "," in value and len(value.split(",")) == 2:
                 # eg. "37.77,122.41"
                 return value.strip()
-            elif (isinstance(value, list) and len(value) == 2 and
-                  isinstance(value[0], numbers.Number) and isinstance(value[1], numbers.Number)):
+            elif (isinstance(value, list) and len(value) == 2
+                  and isinstance(value[0], numbers.Number) and isinstance(value[1], numbers.Number)):
                 # eg. [37.77, 122.41]
                 return ",".join([str(_value) for _value in value])
 
@@ -1059,10 +1059,10 @@ class NativeQuestionAnswerer(BaseQuestionAnswerer):
 
             # tfidf based text resolver
             if (
-                self.has_text_resolver and
-                (not self._text_resolver or
-                 new_hash != self.hash or
-                 self.processor_type != processor_type)
+                self.has_text_resolver
+                and (not self._text_resolver
+                     or new_hash != self.hash
+                     or self.processor_type != processor_type)
             ):
                 # log info
                 msg = f"Creating a text resolver for field '{self.field_name}' in " \
@@ -1089,8 +1089,8 @@ class NativeQuestionAnswerer(BaseQuestionAnswerer):
 
             # embedder based resolver
             if (
-                self.has_embedding_resolver and
-                (not self._embedding_resolver or new_hash != self.hash)
+                self.has_embedding_resolver
+                and (not self._embedding_resolver or new_hash != self.hash)
             ):
                 # log info
                 msg = f"Creating an embedder resolver for field '{self.field_name}' in " \

--- a/mindmeld/components/question_answerer.py
+++ b/mindmeld/components/question_answerer.py
@@ -607,8 +607,10 @@ class NativeQuestionAnswerer(BaseQuestionAnswerer):
             elif isinstance(value, str) and "," in value and len(value.split(",")) == 2:
                 # eg. "37.77,122.41"
                 return value.strip()
-            elif (isinstance(value, list) and len(value) == 2
-                  and isinstance(value[0], numbers.Number) and isinstance(value[1], numbers.Number)):
+            elif (isinstance(value, list)
+                  and len(value) == 2
+                  and isinstance(value[0], numbers.Number)
+                  and isinstance(value[1], numbers.Number)):
                 # eg. [37.77, 122.41]
                 return ",".join([str(_value) for _value in value])
 

--- a/mindmeld/components/request.py
+++ b/mindmeld/components/request.py
@@ -100,7 +100,8 @@ def deserialize_to_lists_of_list_of_immutable_maps(values):
     return tuple([deserialize_to_list_immutable_maps(value) for value in values])
 
 
-@attr.s(frozen=True, kw_only=True)  # pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-instance-attributes
+@attr.s(frozen=True, kw_only=True)
 class Request:
     """
     The Request is an object passed in through the Dialogue Manager and contains all the

--- a/mindmeld/components/role_classifier.py
+++ b/mindmeld/components/role_classifier.py
@@ -17,7 +17,7 @@ This module contains the role classifier component of the MindMeld natural langu
 import logging
 import pickle
 
-from sklearn.externals import joblib
+import joblib
 
 from ._config import get_classifier_config
 from .classifier import Classifier, ClassifierConfig, ClassifierLoadError

--- a/mindmeld/components/role_classifier.py
+++ b/mindmeld/components/role_classifier.py
@@ -17,7 +17,7 @@ This module contains the role classifier component of the MindMeld natural langu
 import logging
 import pickle
 
-import joblib
+from sklearn.externals import joblib
 
 from ._config import get_classifier_config
 from .classifier import Classifier, ClassifierConfig, ClassifierLoadError

--- a/mindmeld/components/role_classifier.py
+++ b/mindmeld/components/role_classifier.py
@@ -339,8 +339,8 @@ class RoleClassifier(Classifier):
 
     def _get_examples_and_labels_hash(self, queries):
         hashable_queries = (
-            [self.domain + "###" + self.intent + "###" + self.entity_type + "###"] +
-            sorted(list(queries.raw_queries()))
+            [self.domain + "###" + self.intent + "###" + self.entity_type + "###"]
+            + sorted(list(queries.raw_queries()))
         )
         return self._resource_loader.hash_list(hashable_queries)
 

--- a/mindmeld/models/embedder_models.py
+++ b/mindmeld/models/embedder_models.py
@@ -70,16 +70,16 @@ class Embedder(ABC):
                     data = pickle.load(fp)
 
                 if (
-                    "_texts" in data and
-                    "_texts_embeddings" in data and
-                    isinstance(data["_texts"], list)
+                    "_texts" in data
+                    and "_texts_embeddings" in data
+                    and isinstance(data["_texts"], list)
                 ):  # new format;
                     self.data = dict(zip(data["_texts"], data["_texts_embeddings"]))
 
                 elif (
-                    "synonyms" in data and
-                    "synonyms_embs" in data and
-                    isinstance(data["synonyms"], dict)
+                    "synonyms" in data
+                    and "synonyms_embs" in data
+                    and isinstance(data["synonyms"], dict)
                 ):  # deprecated format; backwards compatible with ER module code
                     self.data = {key: data["synonyms_embs"][j] for key, j in data["synonyms"]}
 
@@ -564,8 +564,8 @@ class BertEmbedder(Embedder):
         self.transformer_model.eval()
         if show_progress_bar is None:
             show_progress_bar = (
-                logger.getEffectiveLevel() == logging.INFO or
-                logger.getEffectiveLevel() == logging.DEBUG
+                logger.getEffectiveLevel() == logging.INFO
+                or logger.getEffectiveLevel() == logging.DEBUG
             )
 
         if convert_to_tensor:
@@ -637,8 +637,8 @@ class BertEmbedder(Embedder):
                 "to use the built in bert embedder.")
 
         pretrained_name_or_abspath = (
-            kwargs.get("pretrained_name_or_abspath", None) or
-            BertEmbedder.DEFAULT_BERT if self.model_name == "default" else self.model_name
+            kwargs.get("pretrained_name_or_abspath", None)
+            or BertEmbedder.DEFAULT_BERT if self.model_name == "default" else self.model_name
         )
         bert_output_type = kwargs.get("bert_output_type", "mean")
         quantize_model = kwargs.get("quantize_model", False)
@@ -703,8 +703,8 @@ class BertEmbedder(Embedder):
             raise TypeError(f"argument phrases must be of type str or list, not {type(phrases)}")
 
         show_progress_bar = (
-            self._show_progress_bar and
-            (len(phrases) if isinstance(phrases, list) else 1) > 1
+            self._show_progress_bar
+            and (len(phrases) if isinstance(phrases, list) else 1) > 1
         )
 
         # `False` for first call but might not for the subsequent calls

--- a/mindmeld/models/model.py
+++ b/mindmeld/models/model.py
@@ -49,9 +49,6 @@ from .helpers import (
 from .._version import get_mm_version
 from ..text_preparation.text_preparation_pipeline import TextPreparationPipelineFactory
 
-# for backwards compatability for sklearn models serialized and dumped in previous version
-from .labels import LabelEncoder, EntityLabelEncoder  # pylint: disable=unused-import
-
 logger = logging.getLogger(__name__)
 
 

--- a/mindmeld/models/tagger_models.py
+++ b/mindmeld/models/tagger_models.py
@@ -16,7 +16,7 @@ import logging
 import os
 import random
 
-from sklearn.externals import joblib
+import joblib
 
 from .evaluation import EntityModelEvaluation, EvaluatedExample
 from .helpers import (

--- a/mindmeld/models/tagger_models.py
+++ b/mindmeld/models/tagger_models.py
@@ -16,7 +16,7 @@ import logging
 import os
 import random
 
-import joblib
+from sklearn.externals import joblib
 
 from .evaluation import EntityModelEvaluation, EvaluatedExample
 from .helpers import (

--- a/mindmeld/models/tagger_models.py
+++ b/mindmeld/models/tagger_models.py
@@ -186,8 +186,8 @@ class TaggerModel(Model):
                 return TaggerModel.ACCURACY_SCORING
             return get_seq_accuracy_scorer()
         elif (
-            scorer == TaggerModel.ACCURACY_SCORING and
-            classifier_type in TaggerModel.SEQUENCE_MODELS
+            scorer == TaggerModel.ACCURACY_SCORING
+            and classifier_type in TaggerModel.SEQUENCE_MODELS
         ):
             return get_seq_tag_accuracy_scorer()
         else:

--- a/source/userguide/dvc.rst
+++ b/source/userguide/dvc.rst
@@ -28,7 +28,7 @@ Available Options in MindMeld
 +-----------------+------------------------------------------------------------------------+
 | --init          | Initializes DVC within a repository. Must be run before other options. |
 +-----------------+------------------------------------------------------------------------+
-| --setup_dagshub | Setup a central model registry with DAGsHub[1].                        |
+| --setup_dagshub | Setup a central model registry with DAGsHub[1][2].                     |
 +-----------------+------------------------------------------------------------------------+
 | --save          | Saves models using DVC. Run after model building finishes.             |
 +-----------------+------------------------------------------------------------------------+
@@ -42,7 +42,9 @@ Available Options in MindMeld
 | --help          | Show the available options and their descriptions.                     |
 +-----------------+------------------------------------------------------------------------+
 
-[1] The DAGsHub central repository requires you `sign up to DAGsHub <https://dagshub.com/user/sign_up>`_ (it's completely free), and create a project – you can `connect an existing GitHub project <https://dagshub.com/repo/connect>`_ or `create a project from scratch <https://dagshub.com/repo/create>`_.
+- [1] The DAGsHub central repository requires you `sign up to DAGsHub <https://dagshub.com/user/sign_up>`_ (it's free for personal projects), and create a project – you can `connect an existing GitHub project <https://dagshub.com/repo/connect>`_, `migrate a project from any git hosting <https://dagshub.com/repo/migrate>`_ or `create a project from scratch <https://dagshub.com/repo/create>`_.
+
+- [2] `--setup_dagshub` option only works after running `--init`.
 
 We will use the Home Assistant blueprint to demonstrate the various command options.
 

--- a/source/userguide/dvc.rst
+++ b/source/userguide/dvc.rst
@@ -1,11 +1,16 @@
-DVC for Model Tracking
-======================
+DVC & DAGsHub for Model Tracking
+================================
 
 We use Data Version Control, or DVC, in MindMeld in order to track trained models in our applications. DVC is an
 open-source version control system for data science and machine learning projects that enables versioning of large
 files and directories in concert with Git without storing the data itself in Git.
 
+DAGsHub is a platform built on top of Git & DVC that enables users to host, manage and collaborate on their code,
+data, models and experiments. We use DAGsHub in MindMeld as a central model registry, to make our models accessible from anywhere and easily shareable.
+
 You can find more info about DVC in the `official documentation <https://dvc.org/doc>`_.
+
+You can find more info about DAGsHub in the `DAGsHub documentation <https://dagshub.com/docs>`_.
 
 Install DVC using the following command.
 
@@ -13,7 +18,7 @@ Install DVC using the following command.
 
    pip install 'mindmeld[dvc]'
 
-The functionality of the DVC command within MindMeld is shown in the table below.
+The functionality of the DVC & DAGsHub command within MindMeld is shown in the table below.
 
 Available Options in MindMeld
 -----------------------------
@@ -22,6 +27,8 @@ Available Options in MindMeld
 | **Option**      | **Description**                                                        |
 +-----------------+------------------------------------------------------------------------+
 | --init          | Initializes DVC within a repository. Must be run before other options. |
++-----------------+------------------------------------------------------------------------+
+| --setup_dagshub | Setup a central model registry with DAGsHub[1].                        |
 +-----------------+------------------------------------------------------------------------+
 | --save          | Saves models using DVC. Run after model building finishes.             |
 +-----------------+------------------------------------------------------------------------+
@@ -35,6 +42,7 @@ Available Options in MindMeld
 | --help          | Show the available options and their descriptions.                     |
 +-----------------+------------------------------------------------------------------------+
 
+[1] The DAGsHub central repository requires you `sign up to DAGsHub <https://dagshub.com/user/sign_up>`_ (it's completely free), and create a project – you can `connect an existing GitHub project <https://dagshub.com/repo/connect>`_ or `create a project from scratch <https://dagshub.com/repo/create>`_.
 
 We will use the Home Assistant blueprint to demonstrate the various command options.
 
@@ -83,8 +91,19 @@ This will create all the files necessary for DVC to operate.
         new file:   .dvc/plots/smooth.json
         new file:   .dvcignore
 
+4. **[Optional] Setup a central model registry with DAGsHub**
 
-4. **Build the models, save them using DVC, and commit the new files to Git.**
+.. code-block:: console
+
+   python -m home_assistant dvc --setup_dagshub
+
+You will be prompted to input the URL of the DAGsHub project `you created <https://dagshub.com/repo/create>`_, your user name, and your `password (access token) <https://dagshub.com/user/settings/tokens>`_.
+
+You're DVC remote will then point to your DAGsHub storage, with credentials set up for you to save your models directly to your project.
+
+We recommend committing your code to Git and pushing to your connected GitHub project/DAGsHub project using ``git push`` so that you can see your entire project in the DAGsHub UI.
+
+5. **Build the models, save them using DVC, and commit the new files to Git.**
 
 .. code-block:: console
 
@@ -102,7 +121,7 @@ The save command creates a file (.generated.dvc) that tracks the trained models.
 
         new file:   home_assistant/.generated.dvc
 
-5. **Add new training data and follow the same commands in Step 4.**
+6. **Add new training data and follow the same commands in Step 4.**
 
 .. code-block:: console
 
@@ -112,7 +131,7 @@ The save command creates a file (.generated.dvc) that tracks the trained models.
    git commit -m "Updated models with new training data"
 
 
-6. **Switch between different trained models and repo states using the 'checkout' flag.**
+7. **Switch between different trained models and repo states using the 'checkout' flag.**
 
 .. code-block:: console
 


### PR DESCRIPTION
This PR enables Mindmeld users to create a central model registry on DAGsHub, making the model easily accessible and shareable with other team members by hosting all models in a central hub.

This refers to issue #300, which I discussed with @vijay120 and @alhuang10.

I added the option:
`python -m home_assistant dvc --setup_dagshub`

This defines the DVC remote as DAGsHub and guides the user in creating a project and providing the required information (URL, username, and password/access token).

I also edited the documentation to cover this change, and as far as I could test everything is passing.
Looking forward to getting your input on this :)