### PR TITLE
SpaCy versioning changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ requirements = [
     "sklearn-crfsuite>=0.3.6,<1.0",
     "immutables~=0.9",
     "pyyaml>=5.1.1",
-    "spacy~=2.3.1",
+    "spacy>=2.3.1,<2.3.6",
     "mypy>=0.782",
     "marshmallow~=3.7.1",
 ]


### PR DESCRIPTION
SpaCy 2.3.6 has been yanked - https://pypi.org/project/spacy/2.3.6/
So with our current requirements, grabbing the latest match results in an error.  This PR sets the limit to 2.3.5.