### PR TITLE
Relax SpaCy version constraints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ requirements = [
     "sklearn-crfsuite>=0.3.6,<1.0",
     "immutables~=0.9",
     "pyyaml>=5.1.1",
-    "spacy>=2.3.1,<2.3.6",
+    "spacy~=2.3,!=2.3.6",  # avoid 2.3.6 because it was yanked from PyPI
     "mypy>=0.782",
     "marshmallow~=3.7.1",
 ]


### PR DESCRIPTION
This change allows upgrades which don't bump the major version, while
still excluding SpaCy's yanked 2.3.6 release.