### PR TITLE
Fixing value of sys_candidate feature when only one duckling entity is found

### DIFF
--- a/mindmeld/models/query_features.py
+++ b/mindmeld/models/query_features.py
@@ -556,7 +556,7 @@ def extract_sys_candidate_features(start_positions=(0,), **kwargs):
         for token_features in feat_seq:
             for feature, value in token_features.items():
                 if feature.endswith('log_len'):
-                    token_features[feature] = math.log(float(sum(value)) / len(value))
+                    token_features[feature] = math.log((float(sum(value)) / len(value)) + 1)
                 else:
                     token_features[feature] = math.log(value + 1) # Adjust value to be greater than 0
         return feat_seq

--- a/mindmeld/models/query_features.py
+++ b/mindmeld/models/query_features.py
@@ -558,7 +558,7 @@ def extract_sys_candidate_features(start_positions=(0,), **kwargs):
                 if feature.endswith('log_len'):
                     token_features[feature] = math.log(float(sum(value)) / len(value))
                 else:
-                    token_features[feature] = math.log(value)
+                    token_features[feature] = math.log(value + 1) # Adjust value to be greater than 0
         return feat_seq
 
     return _extractor

--- a/tests/test_query_features.py
+++ b/tests/test_query_features.py
@@ -254,7 +254,7 @@ def test_sentiment_query_feature(
                 "sys_candidate|type:sys_interval|granularity:hour|pos:0|log_len",
                 "sys_candidate|type:sys_time|granularity:hour|pos:0|log_len",
             ],
-            [math.log(37 / 3), math.log(2)],
+            [math.log((37 / 3) + 1), math.log(2 + 1)],
             -1,
         ),
         # Test for sys_candidate features for normalized text
@@ -264,7 +264,7 @@ def test_sentiment_query_feature(
                 "sys_candidate|type:sys_interval|granularity:hour|pos:0|log_len",
                 "sys_candidate|type:sys_time|granularity:hour|pos:0|log_len",
             ],
-            [math.log(37 / 3), math.log(2)],
+            [math.log((37 / 3) + 1), math.log(2 + 1)],
             -1,
         ),
     ],
@@ -440,8 +440,8 @@ def test_entity_query_features(
                 "00",
                 "el",
                 "lm",
-                0.0,
                 0.6931471805599453,
+                1.0986122886681098,
             ],
             4,
         ),
@@ -545,21 +545,21 @@ def test_query_token_span_features(kwik_e_mart_nlp):
     for feat in unexpected_features:
         assert feat not in output_features[0]
 
-    assert output_features[0][expected_features[1]] == math.log(len('$2'))
-    assert math.isclose(output_features[0][expected_features[0]], math.log(1.5), rel_tol=1e-04)
+    assert output_features[0][expected_features[1]] == math.log(len('$2') + 1)
+    assert math.isclose(output_features[0][expected_features[0]], math.log(1.5 + 1), rel_tol=1e-04)
 
     output_features = er.view_extracted_features('$20 5')
 
-    assert output_features[0][f'{feature_name}:0'] == math.log(6)
+    assert output_features[0][f'{feature_name}:0'] == math.log(6 + 1)
     assert math.isclose(output_features[0][f'{feature_name}:0|log_len'],
-                        math.log(3.833), rel_tol=1e-04)
-    assert output_features[0][f'{feature_name}:1'] == math.log(5)
+                        math.log(3.833 + 1), rel_tol=1e-04)
+    assert output_features[0][f'{feature_name}:1'] == math.log(5 + 1)
     assert math.isclose(output_features[0][f'{feature_name}:1|log_len'],
-                        math.log(3.8), rel_tol=1e-04)
+                        math.log(3.8 + 1), rel_tol=1e-04)
 
-    assert output_features[1][f'{feature_name}:-1'] == math.log(6)
+    assert output_features[1][f'{feature_name}:-1'] == math.log(6 + 1)
     assert math.isclose(output_features[1][f'{feature_name}:-1|log_len'],
-                        math.log(3.833), rel_tol=1e-04)
-    assert output_features[1][f'{feature_name}:0'] == math.log(5)
+                        math.log(3.833 + 1), rel_tol=1e-04)
+    assert output_features[1][f'{feature_name}:0'] == math.log(5 + 1)
     assert math.isclose(output_features[1][f'{feature_name}:0|log_len'],
-                        math.log(3.8), rel_tol=1e-04)
+                        math.log(3.8 + 1), rel_tol=1e-04)


### PR DESCRIPTION
For queries that have only one numeric entity identified by duckling, we end up setting the value of `sys_candidate|type:{}|granularity:{}|pos:{}` feature which indicates the number of sys_entity matches we had of a particular type and at a particular position to 0 (i.e, log(1)). This is problematic since DictVectorizer also fills in 0 for features not found in a query.

This PR ensures we have a non-zero value when this feature should be active for a query.
Here is some validation done with webex assistant. Context: before integrating the new mindmeld release candidate, the accuracy of the entity recognizer for dev and test sets of the `select` intent were 100 and 98.91 respectively.

With mindmeld version 4.3.5rc5
```
>>> er = nlp.domains['general'].intents['select'].entity_recognizer
>>> er.fit()
True
>>> er.evaluate(label_set='dev')
<EntityModelEvaluation score: 97.65%, 83 of 85 examples correct>
>>> er.evaluate(label_set='test')
<EntityModelEvaluation score: 97.83%, 90 of 92 examples correct>
```

With this change
```
>>> er = nlp.domains['general'].intents['select'].entity_recognizer
>>> er.fit()
True
>>> er.evaluate(label_set='dev')
<EntityModelEvaluation score: 100.00%, 85 of 85 examples correct>
>>> er.evaluate(label_set='test')
<EntityModelEvaluation score: 98.91%, 91 of 92 examples correct>
>>> 
```