### PR TITLE
Bug fix for weird crf predict behaviour

### DIFF
--- a/mindmeld/models/taggers/crf.py
+++ b/mindmeld/models/taggers/crf.py
@@ -78,7 +78,7 @@ class ConditionalRandomFields(Tagger):
             marginal_tuples.append(query_marginal_tuples)
         return marginal_tuples
 
-    def extract_features(self, examples, config, resources, y=None, fit=True, in_memory=False):
+    def extract_features(self, examples, config, resources, y=None, fit=False, in_memory=False):
         """Transforms a list of examples into a feature matrix.
 
         Args:


### PR DESCRIPTION
This is bug fix for the weird behaviour we noticed when using the CRF tagger model. Essential, the predicted tags would change each time. This was because the `fit` argument that is passed to the CRFs feature extractor method is set to `True` by default. So each time `predict()` or `predict_proba()` is called, a new feature vectorizer is created causing inconsistencies. This fix changes the default to `False` and we set it to `True` only during train time.