### PR TITLE
Fixed sqlite bug for py3.6

### DIFF
--- a/mindmeld/core.py
+++ b/mindmeld/core.py
@@ -494,7 +494,7 @@ class ProcessedQuery:
 
     # version the cached data.  Bump this if any changes are made
     # to the to_cache() and from_cache() functions for the core classes.
-    version = 3
+    version = 4
 
     def __init__(
         self,

--- a/mindmeld/query_cache.py
+++ b/mindmeld/query_cache.py
@@ -53,13 +53,12 @@ class QueryCache:
         # Create table to store queries
         cursor.execute("""
         CREATE TABLE IF NOT EXISTS queries
-        (hash_id TEXT PRIMARY KEY, query TEXT, raw_query TEXT, domain TEXT, intent TEXT)
+        (hash_id TEXT PRIMARY KEY, query TEXT, raw_query TEXT, domain TEXT, intent TEXT);
         """)
         # Create table to store the data version
         cursor.execute("""
         CREATE TABLE IF NOT EXISTS version
-        (version_number INTEGER PRIMARY KEY)
-        WITHOUT ROWID;
+        (version_number INTEGER PRIMARY KEY);
         """)
         cursor.execute("""
         INSERT OR IGNORE INTO version values (?);


### PR DESCRIPTION
This error appears on python 3.6 when using the query cache:
```
  File "/opt/app-root/lib/python3.6/site-packages/mindmeld/query_cache.py", line 63, in __init__
    """)
sqlite3.OperationalError: near "WITHOUT": syntax error
```

This is because the `WITHOUT ROWID` clause is not supported in 3.6. This PR fixes the issue.