### PR TITLE
Fix safe path to update rel path

### DIFF
--- a/mindmeld/path.py
+++ b/mindmeld/path.py
@@ -160,10 +160,11 @@ def safe_path(func):
     @wraps(func)
     def _wrapper(*args, **kwargs):
         res = func(*args, **kwargs)
+        # Replace with relpath to avoid replacing : (root dir) with _ in Windows
         if isinstance(res, tuple):
-            return tuple(map(lambda x: x.replace(":", "_") if x else x, res))
+            return tuple(map(lambda x: os.path.relpath(x).replace(":", "_") if x else x, res))
         elif isinstance(res, str):
-            return res.replace(":", "_")
+            return os.path.relpath(res).replace(":", "_")
         else:
             return res
 


### PR DESCRIPTION
This fix should fix the issue with Windows systems mentioned in #307. The issue only arises when the user specifies the absolute path. Works as expected in Windows systems when given the relative path.