### PR TITLE
don't strictly validate elasticsearch type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
             'torch~=1.7.0; python_version>="3.6"',
             'transformers~=3.5.1; python_version>="3.6"',
             'sentence-transformers~=0.3; python_version>="3.6"',
-            "elasticsearch>=7.0",
+            'elasticsearch>=7.0,<7.14',
         ],
         "examples": [
             'connexion>=2.7.0; python_version>="3.6"',
@@ -108,7 +108,7 @@ setup(
             "google-cloud-translate>=3.0.1",
         ],
         "elasticsearch": [
-            "elasticsearch>=5.0",
+            "elasticsearch>=5.0,<7.14",
         ],
         "active_learning": [
             "matplotlib~=3.3.1",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     "click-log==0.1.8",
     "distro~=1.3",
     "dvc>=1.8.1",
-    "elasticsearch>=5.0",
+    "elasticsearch>=5.0,<7.14",
     "Flask~=1.0",
     "Flask-Cors~=3.0",
     "future~=0.17",

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ requirements = [
     "click-log==0.1.8",
     "distro~=1.3",
     "dvc>=1.8.1",
+    # elasticsearch-py 7.14 breaks backwards compatibility with servers prior to 7.11
     "elasticsearch>=5.0,<7.14",
     "Flask~=1.0",
     "Flask-Cors~=3.0",
@@ -94,6 +95,7 @@ setup(
             'torch~=1.7.0; python_version>="3.6"',
             'transformers~=3.5.1; python_version>="3.6"',
             'sentence-transformers~=0.3; python_version>="3.6"',
+            # elasticsearch-py 7.14 breaks backwards compatibility with servers prior to 7.11
             'elasticsearch>=7.0,<7.14',
         ],
         "examples": [
@@ -108,6 +110,7 @@ setup(
             "google-cloud-translate>=3.0.1",
         ],
         "elasticsearch": [
+            # elasticsearch-py 7.14 breaks backwards compatibility with servers prior to 7.11
             "elasticsearch>=5.0,<7.14",
         ],
         "active_learning": [


### PR DESCRIPTION
elasticsearch-py 7.14 strictly validates its Elasticsearch flavor (https://github.com/elastic/elasticsearch-py/commit/b63d00513802ddefa14720043b9dadb85a9e556e)
which makes it reject older versions of elasticsearch that we recommend. Until we are ready to force users to update, we need to not use elasticsearch-py 7.14.