### PR TITLE
Few fixes related to entity recognizer classifier

### DIFF
--- a/mindmeld/components/classifier.py
+++ b/mindmeld/components/classifier.py
@@ -444,6 +444,7 @@ class Classifier(ABC):
                 self._model.dump(path)
 
             hash_path = path + ".hash"
+            os.makedirs(os.path.dirname(hash_path), exist_ok=True)
             with open(hash_path, "w") as hash_file:
                 hash_file.write(self.hash)
 

--- a/mindmeld/components/classifier.py
+++ b/mindmeld/components/classifier.py
@@ -439,8 +439,8 @@ class Classifier(ABC):
             if self._model:
                 # sometimes a model might be NoneType, eg. in role classifiers, in which case,
                 # no dumping is required. While loading such models, the model_path (.pkl)
-                # will not be found and the helpers.load_model() will return None, whic makes it
-                # backwards compataible to loading a NoneType model
+                # will not be found and the helpers.load_model() will return None, which makes it
+                # backwards compatible to loading a NoneType model
                 self._model.dump(path)
 
             hash_path = path + ".hash"

--- a/mindmeld/components/entity_recognizer.py
+++ b/mindmeld/components/entity_recognizer.py
@@ -130,10 +130,7 @@ class EntityRecognizer(Classifier):
 
         if examples:
             # Build entity types set
-            self.entity_types = set()
-            for label in labels:
-                for entity in label:
-                    self.entity_types.add(entity.entity.type)
+            self.entity_types = {entity.entity.type for label in labels for entity in label}
 
             if self.entity_types:
                 model = create_model(self._model_config)

--- a/mindmeld/components/entity_recognizer.py
+++ b/mindmeld/components/entity_recognizer.py
@@ -101,13 +101,17 @@ class EntityRecognizer(Classifier):
         )
         # create model with given params
         self._model_config = self._get_model_config(**kwargs)
-        model = create_model(self._model_config)
 
         label_set = label_set or self._model_config.train_label_set or DEFAULT_TRAIN_SET_REGEX
         queries = self._resolve_queries(queries, label_set)
 
         new_hash = self._get_model_hash(self._model_config, queries)
         cached_model = self._resource_loader.hash_to_model_path.get(new_hash)
+        # In the latest developments, entity.pkl file is not created when there are no entity types,
+        # an act similar to no having domain.pkl or intent.pkl when there are no more than 1 domain
+        # or 1 intent respectively. Previously, this lead to `cached_model=None` but lately, this
+        # will be set to `cached_model=<>.pkl` path and the self.load() takes care of loading
+        # a NoneType model.
 
         if incremental_timestamp and cached_model:
             logger.info("No need to fit.  Previous model is cached.")
@@ -119,16 +123,20 @@ class EntityRecognizer(Classifier):
         # Load labeled data
         examples, labels = self._get_examples_and_labels(queries)
 
-        # Build entity types set
-        self.entity_types = set()
-        for label in labels:
-            for entity in label:
-                self.entity_types.add(entity.entity.type)
+        if examples:
+            # Build entity types set
+            self.entity_types = set()
+            for label in labels:
+                for entity in label:
+                    self.entity_types.add(entity.entity.type)
 
-        model.initialize_resources(self._resource_loader, examples, labels)
-        model.fit(examples, labels)
-        self._model = model
-        self.config = ClassifierConfig.from_model_config(self._model.config)
+            if self.entity_types:
+                model = create_model(self._model_config)
+                model.initialize_resources(self._resource_loader, examples, labels)
+                model.fit(examples, labels)
+                self._model = model
+                self.config = ClassifierConfig.from_model_config(self._model.config)
+
         self.hash = new_hash
 
         self.ready = True
@@ -151,10 +159,13 @@ class EntityRecognizer(Classifier):
     def _dump(self, path):
         er_data = {
             "entity_types": self.entity_types,
-            "w_ngram_freq": self._model.get_resource("w_ngram_freq"),
-            "c_ngram_freq": self._model.get_resource("c_ngram_freq"),
             "model_config": self._model_config,
         }
+        if self._model:
+            er_data.update({
+                "w_ngram_freq": self._model.get_resource("w_ngram_freq"),
+                "c_ngram_freq": self._model.get_resource("c_ngram_freq"),
+            })
         pickle.dump(er_data, open(self._get_classifier_resources_save_path(path), "wb"))
 
     def unload(self):

--- a/mindmeld/components/nlp.py
+++ b/mindmeld/components/nlp.py
@@ -420,6 +420,8 @@ class NaturalLanguageProcessor(Processor):
         self.domain_classifier = DomainClassifier(self.resource_loader)
         self.progress_bar = progress_bar
 
+        # TODO: Move setting self._children to .build() & .load() methods. Same as IntentProcessor,
+        # the setting in .load() should be from a pickled metadata file instead of using os.walk()
         for domain in path.get_domains(self._app_path):
 
             if domain in self._children:
@@ -820,6 +822,8 @@ class DomainProcessor(Processor):
         super().__init__(app_path, resource_loader)
         self.name = domain
         self.intent_classifier = IntentClassifier(self.resource_loader, domain)
+        # TODO: Move setting self._children to .build() & .load() methods. Same as IntentProcessor,
+        # the setting in .load() should be from a pickled metadata file instead of using os.walk()
         intents = path.get_intents(app_path, domain)
 
         # If there is only one intent in the domain, the classifier would not run
@@ -1171,8 +1175,7 @@ class IntentProcessor(Processor):
             self.progress_bar.refresh()
 
         # Create the entity processors
-        entity_types = self.entity_recognizer.entity_types
-        for entity_type in entity_types:
+        for entity_type in self.entity_recognizer.entity_types:
 
             if entity_type in self._children:
                 return
@@ -1209,8 +1212,7 @@ class IntentProcessor(Processor):
         )
 
         # Create the entity processors
-        entity_types = self.entity_recognizer.entity_types
-        for entity_type in entity_types:
+        for entity_type in self.entity_recognizer.entity_types:
 
             if entity_type in self._children:
                 continue

--- a/mindmeld/resource_loader.py
+++ b/mindmeld/resource_loader.py
@@ -455,8 +455,11 @@ class ResourceLoader:
                 hash_val = open(file_path, "r").read()
                 classifier_file_path = file_path.split(".hash")[0]
                 if not os.path.exists(classifier_file_path):
+                    # In some cases, there exists hash file but without a corresponding serialized
+                    # model; which implies that a model was probably not required (eg. only 1 domain
+                    # in case of domain classifier or only 1 intent in an intent classifier or no
+                    # entity types for an entity recognizer)
                     logger.info("Could not find the serialized model")
-                    continue
                 self._hash_to_model_path[hash_val] = classifier_file_path
 
     def _gaz_needs_build(self, gaz_name):

--- a/tests/components/test_nlp.py
+++ b/tests/components/test_nlp.py
@@ -808,11 +808,12 @@ def test_custom_data(kwik_e_mart_nlp):
     store_info_processor = kwik_e_mart_nlp.domains.store_info
 
     store_hours_ent_rec = store_info_processor.intents.get_store_hours.entity_recognizer
+    print(f"**** {store_hours_ent_rec._model_config}")
     assert store_hours_ent_rec._model_config.train_label_set == "testtrain.*\\.txt"
     assert store_hours_ent_rec._model_config.test_label_set == "testtrain.*\\.txt"
 
-    # make sure another intent doesn't have the same custom data specs
-    exit_ent_rec = store_info_processor.intents.exit.entity_recognizer
+    # make sure another intent having an entity recognizer doesn't have the same custom data specs
+    exit_ent_rec = store_info_processor.intents.get_store_number.entity_recognizer
     assert exit_ent_rec._model_config.train_label_set != "testtrain.*\\.txt"
     assert exit_ent_rec._model_config.test_label_set != "testtrain.*\\.txt"
 

--- a/tests/components/test_nlp.py
+++ b/tests/components/test_nlp.py
@@ -808,14 +808,13 @@ def test_custom_data(kwik_e_mart_nlp):
     store_info_processor = kwik_e_mart_nlp.domains.store_info
 
     store_hours_ent_rec = store_info_processor.intents.get_store_hours.entity_recognizer
-    print(f"**** {store_hours_ent_rec._model_config}")
-    assert store_hours_ent_rec._model_config.train_label_set == "testtrain.*\\.txt"
-    assert store_hours_ent_rec._model_config.test_label_set == "testtrain.*\\.txt"
+    assert store_hours_ent_rec._model.config.train_label_set == "testtrain.*\\.txt"
+    assert store_hours_ent_rec._model.config.test_label_set == "testtrain.*\\.txt"
 
     # make sure another intent having an entity recognizer doesn't have the same custom data specs
     exit_ent_rec = store_info_processor.intents.get_store_number.entity_recognizer
-    assert exit_ent_rec._model_config.train_label_set != "testtrain.*\\.txt"
-    assert exit_ent_rec._model_config.test_label_set != "testtrain.*\\.txt"
+    assert exit_ent_rec._model.config.train_label_set != "testtrain.*\\.txt"
+    assert exit_ent_rec._model.config.test_label_set != "testtrain.*\\.txt"
 
 
 def test_dynamic_gazetteer_case_sensitiveness(kwik_e_mart_nlp):


### PR DESCRIPTION
Update:
1. Changes to deprecate  _self.\_model\_config_ are reverted and instead, a TODO is added to deprecate the variable.
---

This PR implements few changes related to entity recognizer classifier:
1. Models for entity recognition are unnecessarily dumped even when there are no entity types. Similar to domain and intent classifiers, this can be avoided.
1. The variable _self.\_model\_config_ seems to have no use apart from being dumped and loaded in metadata. With Phase-1 neural nets PR, the configs of the model are now already saved in a file `<domain/intent/entity>.config.pkl`
1. While evaluating entity recognizers, we do not evaluate on those recognizers who have only one entity type