### PR TITLE
Calculating Token Indices for Sentences that Are not Space Delimited

### DIFF
--- a/mindmeld/core.py
+++ b/mindmeld/core.py
@@ -720,21 +720,24 @@ class NestedEntity:
                     tok_start += 1
             return tok_start
 
-        def _get_token_span(query_span, form_in):
+        def _get_token_span(query_span, form_in, offset):
             """ Get the token span of text based on the normalized token sentence.
             Token span should be calculated based on the normalized token sentence
             as this approach is more robust to sentences that are not space delimited.
 
             Args:
-                query_span (Span): The text span for the token of interest
-                form_in (int): Integer value representing starting text format
+                query_span (Span): The text span for the token of interest.
+                form_in (int): Integer value representing starting text format.
+                offset (int): Offset the final indexing to parent's indexing.
             Returns:
                 tok_span (Span): Span of normalized tokens for the given text.
             """
             # Creating a copy to avoid modifying the original query object
             query_for_norm_transformation = deepcopy(query)
 
-            span_out = query_for_norm_transformation.transform_span(query_span, form_in, TEXT_FORM_NORMALIZED)
+            span_out = query_for_norm_transformation.transform_span(
+                query_span, form_in, TEXT_FORM_NORMALIZED
+            )
             full_norm_text = query_for_norm_transformation.get_text_form(TEXT_FORM_NORMALIZED)
             norm_token_text = span_out.slice(full_norm_text)
             tok_start = _get_token_start(full_norm_text, span_out)
@@ -742,9 +745,18 @@ class NestedEntity:
             # Using a min token len of 1 avoids token span of (x, x - 1) which can become negative.
             norm_token_text_len = len(norm_token_text.split()) or 1
             tok_span = Span(
-                start= tok_start,
-                end= tok_start + norm_token_text_len - 1
+                start=tok_start,
+                end=tok_start + norm_token_text_len - 1
             )
+
+            # convert span from query's indexing to parent's indexing
+            if offset is not None:
+                offset_out = query_for_norm_transformation.transform_index(
+                    offset, form_in, TEXT_FORM_NORMALIZED
+                )
+                tok_offset = len(full_norm_text[:offset_out].split())
+                tok_span.shift(-tok_offset)
+
             return tok_span
 
         def _get_form_details(query_span, offset, form_in, form_out):
@@ -754,7 +766,9 @@ class NestedEntity:
 
             Args:
                 query_span (Span): The text span for the token of interest
+                offset (int): Offset the final indexing to parent's indexing.
                 form_in (int): Integer value representing starting text format
+                form_out (int): Integer value representing final text format
             Returns:
                 text (str): The transformed version of the input text.
                 span_out (Span): Span of the token of interest in the full_norm_text.
@@ -763,14 +777,13 @@ class NestedEntity:
             span_out = query.transform_span(query_span, form_in, form_out)
             full_text = query.get_text_form(form_out)
             text = span_out.slice(full_text)
-            tok_span = _get_token_span(query_span, form_in)
+            tok_span = _get_token_span(query_span, form_in, offset)
 
             # convert span from query's indexing to parent's indexing
             if offset is not None:
                 offset_out = query.transform_index(offset, form_in, form_out)
                 span_out = span_out.shift(-offset_out)
-                tok_offset = len(full_text[:offset_out].split())
-                tok_span.shift(-tok_offset)
+
             return text, span_out, tok_span
 
         if span:

--- a/tests/components/test_entity_recognizer.py
+++ b/tests/components/test_entity_recognizer.py
@@ -30,7 +30,6 @@ def test_tagger_get_stats(kwik_e_mart_app_path, capsys):
     eval.print_stats()
     captured = capsys.readouterr()
     all_elems = set([k for k in captured.out.replace("\n", "").split(" ") if k != ""])
-    print("ALL ELEMS", all_elems)
     assert "Overall" in all_elems
     assert "statistics:" in all_elems
     assert "accuracy" in all_elems

--- a/tests/components/test_entity_recognizer.py
+++ b/tests/components/test_entity_recognizer.py
@@ -30,6 +30,7 @@ def test_tagger_get_stats(kwik_e_mart_app_path, capsys):
     eval.print_stats()
     captured = capsys.readouterr()
     all_elems = set([k for k in captured.out.replace("\n", "").split(" ") if k != ""])
+    print("ALL ELEMS", all_elems)
     assert "Overall" in all_elems
     assert "statistics:" in all_elems
     assert "accuracy" in all_elems


### PR DESCRIPTION
Problem: The root issue is in the _get_form_details() function of the NestedEntity class (core.py), this is where the token spans are calculated for raw, processed, and normalized text. This function calculates the starting and ending token based on the number of whitespace characters in the text (see screenshot). This assumption is problematic for Japanese text such as "1時間のミーティングを30分後から予約" which is not delimited by space. Hence, this creates invalid values for token spans and can cause span assertion errors for Japanese text.

Solution: Redesigned the token span calculation method to more robust to Japanese by solely relying on the Normalized Text by default when calculating token indices. Refactored the existing _get_form_details() function to three separate function, one of which uses the Normalized Text as default after making a copy of the current query object (to avoid transformations in the original query)
