### PR TITLE
Resolve check for whether preprocessors are None in QueryFactory

### DIFF
--- a/mindmeld/query_factory.py
+++ b/mindmeld/query_factory.py
@@ -88,7 +88,7 @@ class QueryFactory:
         char_maps = {}
 
         # Step 1: Preprocessing
-        if self.text_preparation_pipeline.preprocessors:
+        if self.text_preparation_pipeline.custom_preprocessors_exist():
             preprocessed_text = self.text_preparation_pipeline.preprocess(raw_text)
             (
                 forward_map,

--- a/mindmeld/text_preparation/text_preparation_pipeline.py
+++ b/mindmeld/text_preparation/text_preparation_pipeline.py
@@ -82,6 +82,19 @@ class TextPreparationPipeline:
             preprocessed_text = preprocessor.process(preprocessed_text)
         return preprocessed_text
 
+    def custom_preprocessors_exist(self):
+        """ Checks if the current TextPreparationPipeline has preprocessors that is not
+        simply the NoOpPreprocessor or None.
+
+        Returns:
+            has_custom_preprocessors (bool): Whether atleast one custom preprocessor exists.
+        """
+        return (
+            self.preprocessors is not None
+            and len(self.preprocessors) >= 1
+            and not isinstance(self.preprocessors[0], NoOpPreprocessor)
+        )
+
     def normalize(self, text, keep_special_chars=None):
         """Normalize Text.
         Args:


### PR DESCRIPTION
This PR aims to resolve increased memory accumulation. [Data Analysis ](https://cisco-my.sharepoint.com/:x:/p/kunshar2/ERF6hTB91m1DuWffDo0jn08B5HOLaeFVhLhIR2juRWExqQ?e=X9A4co) [Presentation](https://cisco-my.sharepoint.com/:p:/p/kunshar2/ERWll45GZfNHoQKg6rAvqEIBnXjlF4lLM5huWMbA1lBMBw?e=aDrEWy).

Fixes a check in QueryFactory that prevents adding bidirectional character maps between raw and processed data into queries by default. This prevents the increase in memory consumption by around 25%. Visit the "Data Analysis" link to learn more or follow the "Presentation".