### PR TITLE
Forced Dockerfiles to use spacy 3.2.1 to fix Docker build issue with Mimdmeld version 4.4.0

### DIFF
--- a/docker_containers/mindmeld_dep_docker/Dockerfile
+++ b/docker_containers/mindmeld_dep_docker/Dockerfile
@@ -63,12 +63,11 @@ RUN echo alias python=python3  >> /root/.bashrc
 RUN echo alias pip=pip3  >> /root/.bashrc
 
 RUN pip3 install --upgrade pip
-RUN pip3 install -U mindmeld
+RUN pip3 install -U mindmeld spacy==3.1.3
 RUN pip3 install click-log==0.1.8
 
 RUN export LC_ALL=C.UTF-8 && \
     export LANG=C.UTF-8 && \
-    pip3 install mindmeld --upgrade && \
     mindmeld num-parse --start
 
 # Expose ports.
@@ -80,7 +79,6 @@ EXPOSE 7151
 
 ENTRYPOINT export LC_ALL=C.UTF-8 && \
     export LANG=C.UTF-8 && \
-    pip3 install mindmeld --upgrade && \
     mindmeld num-parse --start && \
     su mindmeld -c "ES_JAVA_OPTS='-Xms1g -Xmx1g' /elasticsearch/bin/elasticsearch"
 

--- a/docker_containers/mindmeld_dep_docker/Dockerfile
+++ b/docker_containers/mindmeld_dep_docker/Dockerfile
@@ -63,7 +63,7 @@ RUN echo alias python=python3  >> /root/.bashrc
 RUN echo alias pip=pip3  >> /root/.bashrc
 
 RUN pip3 install --upgrade pip
-RUN pip3 install -U mindmeld spacy==3.1.3
+RUN pip3 install -U mindmeld spacy==3.2.1
 RUN pip3 install click-log==0.1.8
 
 RUN export LC_ALL=C.UTF-8 && \

--- a/docker_containers/mindmeld_docker/Dockerfile
+++ b/docker_containers/mindmeld_docker/Dockerfile
@@ -66,7 +66,7 @@ RUN echo alias python=python3  >> /root/.bashrc
 RUN echo alias pip=pip3  >> /root/.bashrc
 
 RUN pip3 install --upgrade pip
-RUN pip3 install -U mindmeld
+RUN pip3 install -U mindmeld spacy==3.1.3
 RUN pip3 install click-log==0.1.8
 
 ARG REBUILD_BLUEPRINT=unknown
@@ -76,7 +76,6 @@ RUN mkdir -p home_assistant && \
 
 RUN export LC_ALL=C.UTF-8 && \
     export LANG=C.UTF-8 && \
-    pip3 install mindmeld --upgrade && \
     su mindmeld -c "ES_JAVA_OPTS='-Xms1g -Xmx1g' /elasticsearch/bin/elasticsearch -d" && \
     mindmeld num-parse --start && \
     python3 -m home_assistant build
@@ -90,7 +89,6 @@ EXPOSE 7150
 
 ENTRYPOINT export LC_ALL=C.UTF-8 && \
     export LANG=C.UTF-8 && \
-    pip3 install mindmeld --upgrade && \
     su mindmeld -c "ES_JAVA_OPTS='-Xms1g -Xmx1g' /elasticsearch/bin/elasticsearch -d" && \
     mindmeld num-parse --start && \
     /wait_for_cluster_to_turn_green.sh && \

--- a/docker_containers/mindmeld_docker/Dockerfile
+++ b/docker_containers/mindmeld_docker/Dockerfile
@@ -66,7 +66,7 @@ RUN echo alias python=python3  >> /root/.bashrc
 RUN echo alias pip=pip3  >> /root/.bashrc
 
 RUN pip3 install --upgrade pip
-RUN pip3 install -U mindmeld spacy==3.1.3
+RUN pip3 install -U mindmeld spacy==3.2.1
 RUN pip3 install click-log==0.1.8
 
 RUN mkdir -p home_assistant && \

--- a/docker_containers/mindmeld_docker/Dockerfile
+++ b/docker_containers/mindmeld_docker/Dockerfile
@@ -69,7 +69,6 @@ RUN pip3 install --upgrade pip
 RUN pip3 install -U mindmeld spacy==3.1.3
 RUN pip3 install click-log==0.1.8
 
-ARG REBUILD_BLUEPRINT=unknown
 RUN mkdir -p home_assistant && \
     wget https://blueprints.mindmeld.com/home_assistant/app.tar.gz -P /root/projects/ && \
     tar -xvf /root/projects/app.tar.gz -C ./home_assistant


### PR DESCRIPTION
As mentioned in #378, currently the Docker container builds fail because the version of `spacy` installed by mindmeld as a dependency is too old to use the `en_core_web_sm` model currently provided by `spacy`.  This change forces the `spacy` version to be upgraded.

Not sure if this is the best solution to the issue or if updating the required version of `spacy` at https://github.com/cisco/mindmeld/blob/b644c6f843bf96874ef816e0f537eb8ae0862660/setup.py#L39 is better but providing this as a PR in case it helps.