### PR TITLE
Remove Import Error Warning in text_preparation_pipeline.py in create_from_app_path()

### DIFF
--- a/mindmeld/text_preparation/spacy_model_factory.py
+++ b/mindmeld/text_preparation/spacy_model_factory.py
@@ -114,7 +114,7 @@ class SpacyModelFactory:
             spacy_model_name (str): Name of the Spacy NER model (Ex: "en_core_web_sm")
         """
         subprocess.run(
-            ["python", "-m", "spacy", "download", spacy_model_name], check=True
+            ["python", "-m", "spacy", "download", spacy_model_name, "—default-timeout=1000"], check=True
         )
 
     @staticmethod

--- a/mindmeld/text_preparation/spacy_model_factory.py
+++ b/mindmeld/text_preparation/spacy_model_factory.py
@@ -114,7 +114,7 @@ class SpacyModelFactory:
             spacy_model_name (str): Name of the Spacy NER model (Ex: "en_core_web_sm")
         """
         subprocess.run(
-            ["python", "-m", "spacy", "download", spacy_model_name, "—default-timeout=1000"], check=True
+            ["python", "-m", "spacy", "download", spacy_model_name, "--default-timeout=1000"], check=True
         )
 
     @staticmethod

--- a/mindmeld/text_preparation/text_preparation_pipeline.py
+++ b/mindmeld/text_preparation/text_preparation_pipeline.py
@@ -580,6 +580,7 @@ class TextPreparationPipelineFactory:
             TextPreparationPipeline: A TextPreparationPipeline class.
         """
         if app_path:
+            # Check if a custom TextPreparationPipeline has been created in app.py
             try:
                 app = get_app(app_path)
                 if hasattr(app, 'text_preparation_pipeline') and app.text_preparation_pipeline:
@@ -588,10 +589,7 @@ class TextPreparationPipelineFactory:
                     )
                     return app.text_preparation_pipeline
             except MindMeldImportError:
-                logger.warning(
-                    "Error importing application from %s. Using default TextPreparationPipeline.",
-                    app_path
-                )
+                pass
         return TextPreparationPipelineFactory.create_from_app_config(app_path)
 
     @staticmethod


### PR DESCRIPTION
A user can specify a custom TextPreparationPipeline in the app.py module (at app root level). TextPreparationPipelineFactory.create_from_app_path(app_path) checks if app.py file has a custom TextPrepPipeline. Currently, if a custom pipeline is not found in app.py it will give a warning saying the default pipeline is being used. However, the config.py is checked next for a text_preparation_pipeline_config. Only if a custom config is not found in config.py is the default pipeline used. The warning message for when this happens is already handled in TextPreparationPipelineFactory.create_from_app_config(app_path) so having it in the create_from_app_path() function is inaccurate/redundant.