### PR TITLE
Update Elasticsearch dependency.

### DIFF
--- a/docker_containers/mindmeld_dep_docker/Dockerfile
+++ b/docker_containers/mindmeld_dep_docker/Dockerfile
@@ -10,8 +10,8 @@
 # Pull base image.
 FROM ubuntu:18.04
 
-ENV ES_PKG_NAME elasticsearch-7.8.0-linux-x86_64
-ENV ES_FOLDER_NAME elasticsearch-7.8.0
+ENV ES_PKG_NAME elasticsearch-7.16.2-linux-x86_64
+ENV ES_FOLDER_NAME elasticsearch-7.16.2
 
 # System packages
 RUN apt-get update && \


### PR DESCRIPTION
This updates our Elasticsearch dependency in the dependency containers
to mitigate https://www.cve.org/CVERecord?id=CVE-2021-44228.