### PR TITLE
switch quotes so that bumpversion works right

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ current_version = 4.4.1
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>[a-z]+)(?P<revision>\d+)?)?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}{release}{revision}
 	{major}.{minor}.{patch}{release}
 	{major}.{minor}.{patch}
@@ -11,7 +11,7 @@ tag_name = {new_version}
 
 [bumpversion:part:release]
 optional_value = gamma
-values = 
+values =
 	dev
 	alpha
 	beta
@@ -19,12 +19,12 @@ values =
 	gamma
 
 [bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
+search = version="{current_version}"
+replace = version="{new_version}"
 
 [bumpversion:file:mindmeld/_version.py]
-search = current = '{current_version}'
-replace = current = '{new_version}'
+search = current = "{current_version}"
+replace = current = "{new_version}"
 
 [bdist_wheel]
 universal = 1
@@ -33,7 +33,7 @@ universal = 1
 max-line-length = 100
 
 [tool:pytest]
-filterwarnings = 
+filterwarnings =
 	ignore::DeprecationWarning
 
 [aliases]


### PR DESCRIPTION
The bumpversion config patterns had single quotes, but our python files had double quotes, so the version patterns weren't matching right, and we had to manually fix them after running a bump. That should stop happening now.