### PR TITLE
Make few modifications to how resource loader is initialized in NativeQA

### DIFF
--- a/mindmeld/components/__init__.py
+++ b/mindmeld/components/__init__.py
@@ -15,7 +15,7 @@
 from .dialogue import Conversation, DialogueManager, DialogueResponder
 from .entity_resolver import EntityResolver, EntityResolverFactory
 from .nlp import NaturalLanguageProcessor
-from .question_answerer import QuestionAnswerer
+from .question_answerer import QuestionAnswerer, QuestionAnswererFactory
 from .request import Request
 from .custom_action import (
     CustomAction,
@@ -32,6 +32,7 @@ __all__ = [
     "DialogueManager",
     "NaturalLanguageProcessor",
     "QuestionAnswerer",
+    "QuestionAnswererFactory",
     "EntityResolver",
     "EntityResolverFactory",
     "Request",

--- a/mindmeld/components/question_answerer.py
+++ b/mindmeld/components/question_answerer.py
@@ -35,7 +35,6 @@ from nltk.corpus import stopwords as nltk_stopwords
 from nltk.stem import PorterStemmer
 from nltk.tokenize import word_tokenize as nltk_word_tokenize
 
-from mindmeld.query_factory import QueryFactory
 from ._config import (
     get_app_namespace,
     get_classifier_config,
@@ -53,7 +52,9 @@ from ..path import (
     get_question_answerer_index_cache_file_path,
     NATIVE_QUESTION_ANSWERER_INDICES_CACHE_DEFAULT_FOLDER as DEFAULT_APP_PATH
 )
+from ..query_factory import QueryFactory
 from ..resource_loader import Hasher, ResourceLoader
+from ..system_entity_recognizer import NoOpSystemEntityRecognizer
 from ..text_preparation.text_preparation_pipeline import TextPreparationPipelineFactory
 from ..text_preparation.tokenizers import WhiteSpaceTokenizer
 
@@ -395,7 +396,7 @@ class NativeQuestionAnswerer(BaseQuestionAnswerer):
             query_factory = QueryFactory.create_query_factory(
                 app_path=None,
                 text_preparation_pipeline=text_preparation_pipeline,
-                duckling=True
+                system_entity_recognizer=NoOpSystemEntityRecognizer.get_instance()
             )
             resource_loader = ResourceLoader.create_resource_loader(
                 app_path=None,


### PR DESCRIPTION
In the [question_answerer.py](https://github.com/cisco/mindmeld/blob/master/mindmeld/components/question_answerer.py), a ResourceLoader object is required for building models in NativeQA while it is not required for ElasticsearchQA.

Before this PR, the class variable `RESOURCE_LOADER` of NativeQA is always initialized to a newly created resource loader object. However, it is possible that a question-answerer can be called within an app by passing-in an already created/available resource loader. Through this PR, such scenario is accounted for.