### PR TITLE
Updated Dockerfiles to build using current Mindmeld version

### DIFF
--- a/docker_containers/mindmeld_dep_docker/Dockerfile
+++ b/docker_containers/mindmeld_dep_docker/Dockerfile
@@ -55,7 +55,7 @@ COPY ./conf/elasticsearch.yml /elasticsearch/config/elasticsearch.yml
 
 WORKDIR /root
 
-RUN curl -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py
+RUN curl -o /tmp/get-pip.py https://bootstrap.pypa.io/pip/3.6/get-pip.py
 RUN python3 /tmp/get-pip.py
 
 # system as both 2 and 3, make 3 the default
@@ -68,7 +68,6 @@ RUN pip3 install click-log==0.1.8
 
 RUN export LC_ALL=C.UTF-8 && \
     export LANG=C.UTF-8 && \
-    pip3 install mindmeld --upgrade && \
     mindmeld num-parse --start
 
 # Expose ports.
@@ -81,6 +80,5 @@ EXPOSE 7151
 ENTRYPOINT export LC_ALL=C.UTF-8 && \
     export LANG=C.UTF-8 && \
     pip3 install mindmeld --upgrade && \
-    mindmeld num-parse --start && \
     su mindmeld -c "ES_JAVA_OPTS='-Xms1g -Xmx1g' /elasticsearch/bin/elasticsearch"
 

--- a/docker_containers/mindmeld_docker/Dockerfile
+++ b/docker_containers/mindmeld_docker/Dockerfile
@@ -58,7 +58,7 @@ COPY ./wait_for_cluster_to_turn_green.sh /wait_for_cluster_to_turn_green.sh
 
 WORKDIR /root
 
-RUN curl -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py
+RUN curl -o /tmp/get-pip.py https://bootstrap.pypa.io/pip/3.6/get-pip.py
 RUN python3 /tmp/get-pip.py
 
 # system as both 2 and 3, make 3 the default
@@ -66,8 +66,11 @@ RUN echo alias python=python3  >> /root/.bashrc
 RUN echo alias pip=pip3  >> /root/.bashrc
 
 RUN pip3 install --upgrade pip
-RUN pip3 install -U mindmeld
+RUN pip3 install -U mindmeld spacy
 RUN pip3 install click-log==0.1.8
+
+# Add English spacy model or else mindmeld will try to download it itself and fail
+RUN python3 -m spacy download en_core_web_sm --default-timeout=1000
 
 ARG REBUILD_BLUEPRINT=unknown
 RUN mkdir -p home_assistant && \
@@ -76,7 +79,6 @@ RUN mkdir -p home_assistant && \
 
 RUN export LC_ALL=C.UTF-8 && \
     export LANG=C.UTF-8 && \
-    pip3 install mindmeld --upgrade && \
     su mindmeld -c "ES_JAVA_OPTS='-Xms1g -Xmx1g' /elasticsearch/bin/elasticsearch -d" && \
     mindmeld num-parse --start && \
     python3 -m home_assistant build
@@ -90,7 +92,6 @@ EXPOSE 7150
 
 ENTRYPOINT export LC_ALL=C.UTF-8 && \
     export LANG=C.UTF-8 && \
-    pip3 install mindmeld --upgrade && \
     su mindmeld -c "ES_JAVA_OPTS='-Xms1g -Xmx1g' /elasticsearch/bin/elasticsearch -d" && \
     mindmeld num-parse --start && \
     /wait_for_cluster_to_turn_green.sh && \


### PR DESCRIPTION
As stated in Issue #378, currently the Docker builds are unbuildable for both the example docker container and dev container.  This is because currently when mindmeld runs it attempts to install the `en_core_web_sm` model from Spacy but is unable to run the command in the container environment, failes, and the container explodes.  Therefore this PR changes the build by manually having the Docker build add `en_core_web_sm` so that it's already there when mindmeld tests for it and mindmeld itself doesn't have to run it.  Unlike PR #380, this fix is not tied to any poarticular `spacy` version.

Also updated `get-pip.py` scripts to work as the current script will not work with the current container.

To test:

1. Go to `docker_comtainers/mindmeld_docker` and `docker_containers/mindmeld_dev_docker`
2. Run `docker-compose up --build`