### PR TITLE
Support for utf-8 characters

### DIFF
--- a/mindmeld/resource_loader.py
+++ b/mindmeld/resource_loader.py
@@ -440,7 +440,7 @@ class ResourceLoader:
             json_data = {}
         else:
             try:
-                with open(file_path, "r") as json_file:
+                with open(file_path, "r", encoding='utf-8') as json_file:
                     json_data = json.load(json_file)
             except json.JSONDecodeError as e:
                 raise MindMeldError(


### PR DESCRIPTION
Default encoding differs across platforms (i.e. cp1252 in windows) which causes unexpected behaviours with certain character sets. It is suggested to specify the encoding type directly.