### PR TITLE
Refactored Docker Images To Use The Elasticseatch Docker Image As Their Base

### DIFF
--- a/docker_containers/mindmeld_dep_docker/Dockerfile
+++ b/docker_containers/mindmeld_dep_docker/Dockerfile
@@ -8,62 +8,38 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 # Pull base image.
-FROM ubuntu:18.04
-
-ENV ES_PKG_NAME elasticsearch-7.8.0-linux-x86_64
-ENV ES_FOLDER_NAME elasticsearch-7.8.0
+FROM elasticsearch:7.17.4
 
 # System packages
 RUN apt-get update && \
-    apt-get -y install software-properties-common curl vim
+    DEBIAN_FRONTEND="noninteractive" apt-get -y install software-properties-common build-essential curl vim tzdata wget
 
 # Create directories
 RUN mkdir /root/.pip /root/.mindmeld /data
 
-# Install python pip
-RUN apt-get -y install python-pip python3-pip python-dev build-essential && \
-    apt-get -y install software-properties-common
-
-# Install Java
-RUN apt update
-RUN apt-get update
-RUN apt-get install -y wget
-RUN apt install openjdk-8-jdk -y
-
-# Install duckling dependency
-RUN apt-get -y update && \
-    DEBIAN_FRONTEND="noninteractive" apt-get -y upgrade tzdata
-
-# set JAVA_HOME
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
-
-# Install Elasticsearch.
-RUN \
-    cd / && \
-    wget https://artifacts.elastic.co/downloads/elasticsearch/$ES_PKG_NAME.tar.gz && \
-    tar xvzf $ES_PKG_NAME.tar.gz && \
-    rm -f $ES_PKG_NAME.tar.gz && \
-    mv /$ES_FOLDER_NAME /elasticsearch
+# Install Python 3.6
+RUN add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt-get install --no-install-recommends -y python3.6 python3.6-dev python3.6-distutils
+# Register Python 3.6 as the preferred version to use when running python3
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
 
 RUN useradd -ms /bin/bash mindmeld
-RUN mkdir /elasticsearch/log
-RUN chown -R mindmeld:mindmeld /elasticsearch /data /var/log
-
+RUN mkdir -p /elasticsearch/log
+RUN chown -R mindmeld:mindmeld /elasticsearch /usr/share/elasticsearch /data /var/log
 
 # Add Config Files
-COPY ./conf/elasticsearch.yml /elasticsearch/config/elasticsearch.yml
+COPY ./conf/elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
 
 WORKDIR /root
 
 RUN curl -o /tmp/get-pip.py https://bootstrap.pypa.io/pip/3.6/get-pip.py
 RUN python3 /tmp/get-pip.py
 
-# system as both 2 and 3, make 3 the default
-RUN echo alias python=python3  >> /root/.bashrc
-RUN echo alias pip=pip3  >> /root/.bashrc
-
 RUN pip3 install --upgrade pip
-RUN pip3 install -U mindmeld
+# Explicitly install numpy to support arm builds
+RUN pip3 install -U numpy~=1.15
+# Install spacy with mindmeld to ensure a version new enough is installed to install en_core_web_sm
+RUN pip3 install -U mindmeld spacy
 RUN pip3 install click-log==0.1.8
 
 RUN export LC_ALL=C.UTF-8 && \
@@ -80,5 +56,5 @@ EXPOSE 7151
 ENTRYPOINT export LC_ALL=C.UTF-8 && \
     export LANG=C.UTF-8 && \
     pip3 install mindmeld --upgrade && \
-    su mindmeld -c "ES_JAVA_OPTS='-Xms1g -Xmx1g' /elasticsearch/bin/elasticsearch"
+    su mindmeld -c "ES_JAVA_OPTS='-Xms1g -Xmx1g' /usr/share/elasticsearch/bin/elasticsearch"
 

--- a/docker_containers/mindmeld_dep_docker/Dockerfile
+++ b/docker_containers/mindmeld_dep_docker/Dockerfile
@@ -7,8 +7,8 @@
 #                                                                   #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-# Pull base image.
-FROM elasticsearch:7.17.4
+# Pull base elastisearch image
+FROM elasticsearch:7.17.5
 
 # System packages
 RUN apt-get update && \
@@ -36,8 +36,6 @@ RUN curl -o /tmp/get-pip.py https://bootstrap.pypa.io/pip/3.6/get-pip.py
 RUN python3 /tmp/get-pip.py
 
 RUN pip3 install --upgrade pip
-# Explicitly install numpy to support arm builds
-RUN pip3 install -U numpy~=1.15
 # Install spacy with mindmeld to ensure a version new enough is installed to install en_core_web_sm
 RUN pip3 install -U mindmeld spacy
 RUN pip3 install click-log==0.1.8

--- a/docker_containers/mindmeld_docker/Dockerfile
+++ b/docker_containers/mindmeld_docker/Dockerfile
@@ -7,8 +7,8 @@
 #                                                                   #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-# Pull base image.
-FROM elasticsearch:7.17.4
+# Pull base elastisearch image
+FROM elasticsearch:7.17.5
 
 # System packages
 RUN apt-get update && \
@@ -39,8 +39,6 @@ RUN curl -o /tmp/get-pip.py https://bootstrap.pypa.io/pip/3.6/get-pip.py
 RUN python3 /tmp/get-pip.py
 
 RUN pip3 install --upgrade pip
-# Explicitly install numpy to support arm builds
-RUN pip3 install -U numpy~=1.15
 # Install spacy with mindmeld to ensure a version new enough is installed to install en_core_web_sm
 RUN pip3 install -U mindmeld spacy
 RUN pip3 install click-log==0.1.8

--- a/docker_containers/mindmeld_docker/Dockerfile
+++ b/docker_containers/mindmeld_docker/Dockerfile
@@ -8,50 +8,27 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 # Pull base image.
-FROM ubuntu:18.04
-
-ENV ES_PKG_NAME elasticsearch-7.8.0-linux-x86_64
-ENV ES_FOLDER_NAME elasticsearch-7.8.0
+FROM elasticsearch:7.17.4
 
 # System packages
 RUN apt-get update && \
-    apt-get -y install software-properties-common curl vim
+    DEBIAN_FRONTEND="noninteractive" apt-get -y install software-properties-common build-essential curl vim tzdata wget
 
 # Create directories
 RUN mkdir /root/.pip /root/.mindmeld /data
 
-# Install python pip
-RUN apt-get -y install python-pip python3-pip python-dev build-essential && \
-    apt-get -y install software-properties-common
-
-# Install Java
-RUN apt update
-RUN apt-get update
-RUN apt-get install -y wget
-RUN apt install openjdk-8-jdk -y
-
-# Install duckling dependency
-RUN apt-get -y update && \
-    DEBIAN_FRONTEND="noninteractive" apt-get -y upgrade tzdata
-
-# set JAVA_HOME
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
-
-# Install Elasticsearch.
-RUN \
-    cd / && \
-    wget https://artifacts.elastic.co/downloads/elasticsearch/$ES_PKG_NAME.tar.gz && \
-    tar xvzf $ES_PKG_NAME.tar.gz && \
-    rm -f $ES_PKG_NAME.tar.gz && \
-    mv /$ES_FOLDER_NAME /elasticsearch
+# Install Python 3.6
+RUN add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt-get install --no-install-recommends -y python3.6 python3.6-dev python3.6-distutils
+# Register Python 3.6 as the preferred version to use when running python3
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
 
 RUN useradd -ms /bin/bash mindmeld
-RUN mkdir /elasticsearch/log
-RUN chown -R mindmeld:mindmeld /elasticsearch /data /var/log
-
+RUN mkdir -p /elasticsearch/log
+RUN chown -R mindmeld:mindmeld /elasticsearch /usr/share/elasticsearch /data /var/log
 
 # Add Config Files
-COPY ./conf/elasticsearch.yml /elasticsearch/config/elasticsearch.yml
+COPY ./conf/elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
 
 # Add Cluster Status Script
 COPY ./wait_for_cluster_to_turn_green.sh /wait_for_cluster_to_turn_green.sh
@@ -61,11 +38,10 @@ WORKDIR /root
 RUN curl -o /tmp/get-pip.py https://bootstrap.pypa.io/pip/3.6/get-pip.py
 RUN python3 /tmp/get-pip.py
 
-# system as both 2 and 3, make 3 the default
-RUN echo alias python=python3  >> /root/.bashrc
-RUN echo alias pip=pip3  >> /root/.bashrc
-
 RUN pip3 install --upgrade pip
+# Explicitly install numpy to support arm builds
+RUN pip3 install -U numpy~=1.15
+# Install spacy with mindmeld to ensure a version new enough is installed to install en_core_web_sm
 RUN pip3 install -U mindmeld spacy
 RUN pip3 install click-log==0.1.8
 
@@ -79,7 +55,7 @@ RUN mkdir -p home_assistant && \
 
 RUN export LC_ALL=C.UTF-8 && \
     export LANG=C.UTF-8 && \
-    su mindmeld -c "ES_JAVA_OPTS='-Xms1g -Xmx1g' /elasticsearch/bin/elasticsearch -d" && \
+    su mindmeld -c "ES_JAVA_OPTS='-Xms1g -Xmx1g' /usr/share/elasticsearch/bin/elasticsearch -d" && \
     mindmeld num-parse --start && \
     python3 -m home_assistant build
 
@@ -92,7 +68,7 @@ EXPOSE 7150
 
 ENTRYPOINT export LC_ALL=C.UTF-8 && \
     export LANG=C.UTF-8 && \
-    su mindmeld -c "ES_JAVA_OPTS='-Xms1g -Xmx1g' /elasticsearch/bin/elasticsearch -d" && \
+    su mindmeld -c "ES_JAVA_OPTS='-Xms1g -Xmx1g' /usr/share/elasticsearch/bin/elasticsearch -d" && \
     mindmeld num-parse --start && \
     /wait_for_cluster_to_turn_green.sh && \
     python3 -m home_assistant run


### PR DESCRIPTION
So as part of attempting to solve #422 (but not doing so because of [the issue with MindMeld downloading an x86 build of Duckling from a bucket](https://github.com/cisco/mindmeld/issues/422#issuecomment-1160668153), I refactored the current Docker containers to instead of being based on a standard Ubuntu image to be based from [the official Elasticsearch Docker image](https://hub.docker.com/_/elasticsearch).  This provides the benefit of instead of having to manually download Elasticsearch into the MindMeld container, it's already there, allowing for faster builds.  In addition, it also allows for easy bumping of the Elasticsearch version in 1 place with minimal overhead so issues like the version update being discussed in #386 can easily be taken care of from a Docker perspective.

Also saw @vrdn-23 and @tmehlinger's [comments in #386](https://github.com/cisco/mindmeld/pull/386#issuecomment-1074247564) mentioning looking into this container so decided to make a PR with what I had.

Like I said, did this trying to solve #422 and it not working out but figured might as well contribute the refactor and see if it was something y'all were interested in.

To test, run `docker compose up --build` in the `docker_containers/mindmeld_dep_docker` and `docker_containers/mindmeld_docker` directories.