### PR TITLE
Change behavior of param and param selection merging

### DIFF
--- a/mindmeld/components/_config.py
+++ b/mindmeld/components/_config.py
@@ -560,11 +560,12 @@ class NlpConfigError(Exception):
 
 def merge_param_configs(default_dict, user_defined_dict):
     new_dict = dict(user_defined_dict)
-    if "params" in default_dict:
-        if "params" in user_defined_dict:
-            new_dict["params"] = {**default_dict["params"], **user_defined_dict["params"]}
-        else:
-            new_dict["params"] = default_dict["params"]
+    if "params" not in default_dict:
+        return new_dict
+    if "params" in user_defined_dict:
+        new_dict["params"] = {**default_dict["params"], **user_defined_dict["params"]}
+    else:
+        new_dict["params"] = default_dict["params"]
     return new_dict
 
 

--- a/mindmeld/components/_config.py
+++ b/mindmeld/components/_config.py
@@ -560,12 +560,11 @@ class NlpConfigError(Exception):
 
 def merge_param_configs(default_dict, user_defined_dict):
     new_dict = dict(user_defined_dict)
-    if "params" not in default_dict:
-        return new_dict
-    if "params" in user_defined_dict:
-        new_dict["params"] = {**default_dict["params"], **user_defined_dict["params"]}
-    else:
-        new_dict["params"] = default_dict["params"]
+    if "params" in default_dict:
+        if "params" in user_defined_dict:
+            new_dict["params"] = {**default_dict["params"], **user_defined_dict["params"]}
+        else:
+            new_dict["params"] = default_dict["params"]
     return new_dict
 
 

--- a/mindmeld/components/_config.py
+++ b/mindmeld/components/_config.py
@@ -557,21 +557,15 @@ DEFAULT_EN_TEXT_PREPARATION_CONFIG = {
 class NlpConfigError(Exception):
     pass
 
-def clean_param_configs(default_dict, user_defined_dict):
-    pass
 
-def merge_recursive_dict(default_dict, user_defined_dict):
-    for key in user_defined_dict:
-        if key in default_dict:
-            if isinstance(default_dict[key], dict) and isinstance(user_defined_dict[key], dict):
-                merge_recursive_dict(default_dict[key], user_defined_dict[key])
-            elif default_dict[key] == user_defined_dict[key]:
-                pass  # same leaf value
-            else:
-                default_dict[key] = user_defined_dict[key]
+def merge_param_configs(default_dict, user_defined_dict):
+    new_dict = dict(user_defined_dict)
+    if "params" in default_dict:
+        if "params" in user_defined_dict:
+            new_dict["params"] = {**default_dict["params"], **user_defined_dict["params"]}
         else:
-            default_dict[key] = user_defined_dict[key]
-    return default_dict
+            new_dict["params"] = default_dict["params"]
+    return new_dict
 
 
 def get_custom_action_config(app_path):
@@ -768,7 +762,7 @@ def get_classifier_config(
             try:
                 raw_args = {"domain": domain, "intent": intent, "entity": entity}
                 args = {k: raw_args[k] for k in func_args}
-                return merge_recursive_dict(_get_default_classifier_config(clf_type), copy.deepcopy(func(**args)))
+                return merge_param_configs(_get_default_classifier_config(clf_type), copy.deepcopy(func(**args)))
             except Exception as exc:  # pylint: disable=broad-except
                 # Note: this is intentionally broad -- provider could raise any exception
                 logger.warning(
@@ -784,8 +778,8 @@ def get_classifier_config(
         "question_answering": "QUESTION_ANSWERER_CONFIG",
     }[clf_type]
     try:
-        return merge_recursive_dict(_get_default_classifier_config(clf_type),
-                                    copy.deepcopy(getattr(module_conf, attr_name)))
+        return merge_param_configs(_get_default_classifier_config(clf_type),
+                                   copy.deepcopy(getattr(module_conf, attr_name)))
     except AttributeError:
         try:
             result = copy.deepcopy(

--- a/mindmeld/components/classifier.py
+++ b/mindmeld/components/classifier.py
@@ -416,10 +416,6 @@ class Classifier(ABC):
 
             model_config.update(kwargs)
 
-            # If a parameter selection grid was passed in at runtime, override params set in the
-            # application specified or default config
-            # if kwargs.get("param_selection") and not kwargs.get("params"):
-            #     model_config.pop("params", None)
         return ModelConfig(**model_config)
 
     def dump(self, model_path, incremental_model_path=None):

--- a/mindmeld/components/classifier.py
+++ b/mindmeld/components/classifier.py
@@ -411,12 +411,15 @@ class Classifier(ABC):
             if not loaded_config:
                 logger.warning("loaded_config is not passed in")
             model_config = loaded_config or {}
+            if 'params' in model_config and 'params' in kwargs:
+                kwargs['params'].update(model_config['params'])
+
             model_config.update(kwargs)
 
             # If a parameter selection grid was passed in at runtime, override params set in the
             # application specified or default config
-            if kwargs.get("param_selection") and not kwargs.get("params"):
-                model_config.pop("params", None)
+            # if kwargs.get("param_selection") and not kwargs.get("params"):
+            #     model_config.pop("params", None)
         return ModelConfig(**model_config)
 
     def dump(self, model_path, incremental_model_path=None):

--- a/mindmeld/models/model.py
+++ b/mindmeld/models/model.py
@@ -463,9 +463,16 @@ class Model(AbstractModel):
 
         param_grid = self._convert_params(selection_settings["grid"], labels)
         model_class = self._get_model_constructor()
-        for key, val in fixed_params.items():
-            if key not in param_grid:
-                param_grid[key] = [val]
+        if fixed_params:
+            for key, val in fixed_params.items():
+                if key not in param_grid:
+                    param_grid[key] = [val]
+                else:
+                    logger.info(
+                        "Found parameter %s both in params and param_selection. Proceeding with param_selection.. \
+                        (If you did not set this, it could be a Mindmeld default.)",
+                        key
+                    )
         estimator, param_grid = self._get_cv_estimator_and_params(
             model_class, param_grid
         )

--- a/mindmeld/models/model.py
+++ b/mindmeld/models/model.py
@@ -429,7 +429,7 @@ class Model(AbstractModel):
     def _get_model_constructor(self):
         raise NotImplementedError
 
-    def _fit_cv(self, examples, labels, groups=None, selection_settings=None):
+    def _fit_cv(self, examples, labels, groups=None, selection_settings=None, fixed_params=None):
         """Called by the fit method when cross validation parameters are passed in. Runs cross
         validation and returns the best estimator and parameters.
 
@@ -463,6 +463,9 @@ class Model(AbstractModel):
 
         param_grid = self._convert_params(selection_settings["grid"], labels)
         model_class = self._get_model_constructor()
+        for key, val in fixed_params.items():
+            if key not in param_grid:
+                param_grid[key] = [val]
         estimator, param_grid = self._get_cv_estimator_and_params(
             model_class, param_grid
         )

--- a/mindmeld/models/tagger_models.py
+++ b/mindmeld/models/tagger_models.py
@@ -217,7 +217,7 @@ class TaggerModel(Model):
             labels (ProcessedQueryList.EntitiesIterator): A list of expected labels.
             params (dict): Parameters of the classifier.
         """
-        skip_param_selection = params is not None or self.config.param_selection is None
+        skip_param_selection = self.config.param_selection is None
         params = params or self.config.params
 
         # Shuffle to prevent order effects

--- a/mindmeld/models/tagger_models.py
+++ b/mindmeld/models/tagger_models.py
@@ -253,7 +253,7 @@ class TaggerModel(Model):
             if isinstance(self._clf, non_supported_classes):
                 raise MindMeldError(f"The {type(self._clf).__name__} model does not support cross-validation")
 
-            _, best_params = self._fit_cv(X, y, groups)
+            _, best_params = self._fit_cv(X, y, groups, fixed_params=params)
             self._clf = self._fit(X, y, best_params)
             self._current_params = best_params
 

--- a/mindmeld/models/text_models.py
+++ b/mindmeld/models/text_models.py
@@ -434,7 +434,7 @@ class TextModel(Model):
                 interfaces.
         """
         params = params or self.config.params
-        skip_param_selection = params is not None or self.config.param_selection is None
+        skip_param_selection = self.config.param_selection is None
 
         # Shuffle to prevent order effects
         indices = list(range(len(labels)))
@@ -454,7 +454,7 @@ class TextModel(Model):
             self._current_params = params
         else:
             # run cross validation to select params
-            best_clf, best_params = self._fit_cv(X, y, groups)
+            best_clf, best_params = self._fit_cv(X, y, groups, fixed_params=params)
             self._clf = best_clf
             self._current_params = best_params
 

--- a/tests/components/test_config.py
+++ b/tests/components/test_config.py
@@ -128,7 +128,7 @@ def test_get_classifier_config_func():
         "entity", APP_PATH, domain="domain", intent="intent"
     )["params"]
 
-    expected = {"penalty": "l2", "C": 100}
+    expected = {"penalty": "l2", "C": 100, "solver": "liblinear"}
 
     assert actual == expected
 
@@ -139,7 +139,7 @@ def test_get_classifier_config_func_error():
         "params"
     ]
 
-    expected = {"error": "intent", "penalty": "l2", "C": 100}
+    expected = {"error": "intent", "penalty": "l2", "C": 100, "solver": "liblinear"}
 
     assert actual == expected
 

--- a/tests/components/test_intent_classifier.py
+++ b/tests/components/test_intent_classifier.py
@@ -74,3 +74,4 @@ def test_intent_classifier_random_forest(kwik_e_mart_app_path, caplog):
         mock.assert_any_call(
             "Unexpected param `fit_intercept`, dropping it from model config."
         )
+        mock.assert_any_call("Unexpected param `solver`, dropping it from model config.")


### PR DESCRIPTION
## What is the change?
With this PR, we are introducing a new change in how Mindmeld deals with _params_ and _param_selection_ in model configuration files. 

## What was the earlier behaviour?
- If there was any configuration that was provided in the config file for a Mindmeld application, we would completely ignore the default configuration. 
- If we have both _params_ and _param_selection_ in a config, we would run the param selection on the specified params and ignore the values in params. 

## What is the new behaviour?
- If there was any configuration that was provided in the config file for a Mindmeld application, we now merge the params of the Mindmeld default and the user-defined config. (Conflicting params are overridden in favor of the user-defined config)
- If we have both params and param_selection in a config, we run the cross-validation grid on the values specified in _param_selection_ and choose the best model parameters while also including the values in _params_ fixed during selection. If we have any values that are common in both _params_ and _param_selection_, we inform the user of the conflict, and proceed with running param selection on that value. 

## Why are we doing this?
This change is introduced to for two main reasons:
1) In order to help facilitate the update process for scikit-learn, we need to eventually change the default solver for our text and tagger models. In order to make sure this change can be applied everywhere uniformly, it makes sense that we have it stored in our default configurations. This change also allows us to easily adapt to new configuration changes from the scikit-learn side of things with minimal code overhead for us.
2) The behavior of _param_selection_ when we also have _params_ defined seems unintuitive. A user that defines a value in _params_ is sure of it, and would want that value to be reflected across the model and expects a _param_selection_ across the range of values defined while also making sure these are the best params we can get with the fixed _params_ values included. This new change implements this behavior.