### PR TITLE
Major bug fix for PyTorch CRF

### DIFF
--- a/mindmeld/models/taggers/crf.py
+++ b/mindmeld/models/taggers/crf.py
@@ -331,6 +331,17 @@ class TorchCrfTagger(Tagger):
         best_model_save_path = os.path.join(os.path.split(path)[0], "best_crf_wts.pt")
         self._clf.save_best_weights_path(best_model_save_path)
 
+    def load(self, path):
+        best_model_save_path = os.path.join(os.path.split(path)[0], "best_crf_wts.pt")
+        self._clf.build_params(*self.get_torch_encoder().get_feats_and_classes())
+        self._clf.load_best_weights_path(best_model_save_path)
+
+    def get_torch_encoder(self):
+        return self._clf.get_encoder()
+
+    def set_torch_encoder(self, encoder):
+        self._clf.set_encoder(encoder)
+
 
 # Feature extraction for CRF
 

--- a/mindmeld/models/taggers/pytorch_crf.py
+++ b/mindmeld/models/taggers/pytorch_crf.py
@@ -273,8 +273,6 @@ class TorchCrfModel(nn.Module):
         self.optimizer = None
         self.random_state = None
 
-        # self.best_model_save_path = None
-        self.ready = False
         self.tmp_save_path = os.path.join(mkdtemp(), "best_crf_wts.pt")
 
     def get_encoder(self):
@@ -368,7 +366,7 @@ class TorchCrfModel(nn.Module):
             inputs.values()[:] = inputs.values() * dp_mask
         dense_W = torch.tile(self.W, dims=(mask.shape[0], 1))
         out_1 = torch.addmm(self.b, inputs, dense_W)
-        crf_input = out_1.reshape((mask.shape[0], -1, self.num_classes or self.encoder.num_classes))
+        crf_input = out_1.reshape((mask.shape[0], -1, self.num_classes))
         if targets is None:
             return self.crf_layer.decode(crf_input, mask=mask)
         loss = - self.crf_layer(crf_input, targets, mask=mask)
@@ -445,7 +443,7 @@ class TorchCrfModel(nn.Module):
         # SWITCHING FOR BATCH FIRST DEFAULT
         dense_W = torch.tile(self.W, dims=(mask.shape[0], 1))
         out_1 = torch.addmm(self.b, inputs, dense_W)
-        emissions = out_1.reshape((mask.shape[0], -1, self.num_classes or self.encoder.num_classes))
+        emissions = out_1.reshape((mask.shape[0], -1, self.num_classes))
         emissions = emissions.transpose(0, 1)
         mask = mask.transpose(0, 1)
         alpha = self._compute_log_alpha(emissions, mask, run_backwards=False)

--- a/mindmeld/models/taggers/pytorch_crf.py
+++ b/mindmeld/models/taggers/pytorch_crf.py
@@ -6,7 +6,7 @@ from collections import Counter
 from copy import copy
 from itertools import chain
 from random import randint
-from tempfile import gettempdir
+from tempfile import mkdtemp
 
 import numpy as np
 import torch
@@ -272,7 +272,7 @@ class TorchCrfModel(nn.Module):
 
         self.best_model_save_path = None
         self.ready = False
-        self.tmp_save_path = os.path.join(gettempdir(), "best_crf_wts.pt")
+        self.tmp_save_path = os.path.join(mkdtemp(), "best_crf_wts.pt")
         # os.makedirs(os.path.dirname(self.tmp_save_path), exist_ok=True)
 
     def set_random_states(self):
@@ -287,7 +287,7 @@ class TorchCrfModel(nn.Module):
         Args:
             path (str): Path to save the best model weights.
         """
-        self.best_model_save_path = path
+        self.best_model_save_path = os.path.abspath(path)
         if os.path.exists(self.tmp_save_path):
             best_weights = torch.load(self.tmp_save_path)
             torch.save(best_weights, self.best_model_save_path)

--- a/mindmeld/models/taggers/pytorch_crf.py
+++ b/mindmeld/models/taggers/pytorch_crf.py
@@ -293,11 +293,7 @@ class TorchCrfModel(nn.Module):
         Args:
             path (str): Path to save the best model weights.
         """
-        if os.path.exists(self.tmp_save_path):
-            best_weights = torch.load(self.tmp_save_path)
-            torch.save(best_weights, path)
-        else:
-            raise MindMeldError("CRF weights not saved. Please re-train model from scratch.")
+        torch.save(self.state_dict(), path)
 
     def load_best_weights_path(self, path):
         """Saves the best weights of the model to a path in the .generated folder.


### PR DESCRIPTION
There are two minor fixes in the PyTorch-CRF code that this PR resolves:
1) The best path for a model was not saving the absolute path the first time and hence, the model loading was throwing issues when invoked from a directory that was different from when training was called.
2) The tempfile function I was using returned the same temp directory each time and this would cause the code to save the same model across different entity recognition models.

UPDATE:
This PR has now evolved into changing the way we now dump and load PyTorch CRF models. We no longer dump the entire class object to the entity pickle, but rather save only the config and encoder details, thus following a approach more in line with the LSTM model. 