### PR TITLE
Minor nits and fixing stuff related to PyTorch CRF

### DIFF
--- a/mindmeld/models/tagger_models.py
+++ b/mindmeld/models/tagger_models.py
@@ -455,6 +455,7 @@ class TaggerModel(Model):
                 # replace model dump directory with actual model
             elif metadata.get('model_type') == 'torch-crf':
                 model._clf.set_params(**metadata["model_config"].params)
+                model._current_params = model._clf.get_params()
                 model._clf.set_torch_encoder(metadata['feature_and_label_encoder'])
                 model._clf.load(path)
 


### PR DESCRIPTION
This PR covers some things that provide minor fixes to some issues related to the PyTorch CRF.

Changes include:
- Included the get_params() for torch-crf which I didn't implement the first time around
- Set the current_params when loading the model, so that params are saved during save-params command in ANLP (h/t to @serapio for pointing this out)
- Updated some doc strings
- Made the temp file to save CRF path as a temporary context rather than as a class attribute.