### PR TITLE
Removed unneeded OpenJDK install from docker images and updated Elastisearch to 7.17.8

### DIFF
--- a/docker_containers/mindmeld_dep_docker/Dockerfile
+++ b/docker_containers/mindmeld_dep_docker/Dockerfile
@@ -10,12 +10,12 @@
 # Pull base image.
 FROM ubuntu:18.04
 
-ENV ES_PKG_NAME elasticsearch-7.8.0-linux-x86_64
-ENV ES_FOLDER_NAME elasticsearch-7.8.0
+ENV ES_PKG_NAME elasticsearch-7.17.8-linux-x86_64
+ENV ES_FOLDER_NAME elasticsearch-7.17.8
 
 # System packages
 RUN apt-get update && \
-    apt-get -y install software-properties-common curl vim
+    apt-get -y install software-properties-common curl vim wget
 
 # Create directories
 RUN mkdir /root/.pip /root/.mindmeld /data
@@ -24,18 +24,9 @@ RUN mkdir /root/.pip /root/.mindmeld /data
 RUN apt-get -y install python-pip python3-pip python-dev build-essential && \
     apt-get -y install software-properties-common
 
-# Install Java
-RUN apt update
-RUN apt-get update
-RUN apt-get install -y wget
-RUN apt install openjdk-8-jdk -y
-
 # Install duckling dependency
 RUN apt-get -y update && \
     DEBIAN_FRONTEND="noninteractive" apt-get -y upgrade tzdata
-
-# set JAVA_HOME
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 # Install Elasticsearch.
 RUN \
@@ -48,7 +39,6 @@ RUN \
 RUN useradd -ms /bin/bash mindmeld
 RUN mkdir /elasticsearch/log
 RUN chown -R mindmeld:mindmeld /elasticsearch /data /var/log
-
 
 # Add Config Files
 COPY ./conf/elasticsearch.yml /elasticsearch/config/elasticsearch.yml

--- a/docker_containers/mindmeld_docker/Dockerfile
+++ b/docker_containers/mindmeld_docker/Dockerfile
@@ -10,12 +10,12 @@
 # Pull base image.
 FROM ubuntu:18.04
 
-ENV ES_PKG_NAME elasticsearch-7.8.0-linux-x86_64
-ENV ES_FOLDER_NAME elasticsearch-7.8.0
+ENV ES_PKG_NAME elasticsearch-7.17.8-linux-x86_64
+ENV ES_FOLDER_NAME elasticsearch-7.17.8
 
 # System packages
 RUN apt-get update && \
-    apt-get -y install software-properties-common curl vim
+    apt-get -y install software-properties-common curl vim wget
 
 # Create directories
 RUN mkdir /root/.pip /root/.mindmeld /data
@@ -24,18 +24,9 @@ RUN mkdir /root/.pip /root/.mindmeld /data
 RUN apt-get -y install python-pip python3-pip python-dev build-essential && \
     apt-get -y install software-properties-common
 
-# Install Java
-RUN apt update
-RUN apt-get update
-RUN apt-get install -y wget
-RUN apt install openjdk-8-jdk -y
-
 # Install duckling dependency
 RUN apt-get -y update && \
     DEBIAN_FRONTEND="noninteractive" apt-get -y upgrade tzdata
-
-# set JAVA_HOME
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 # Install Elasticsearch.
 RUN \
@@ -48,7 +39,6 @@ RUN \
 RUN useradd -ms /bin/bash mindmeld
 RUN mkdir /elasticsearch/log
 RUN chown -R mindmeld:mindmeld /elasticsearch /data /var/log
-
 
 # Add Config Files
 COPY ./conf/elasticsearch.yml /elasticsearch/config/elasticsearch.yml


### PR DESCRIPTION
## Summary

As described in the [documentation for Elastisearch 7](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/setup.html), the download of Elastisearch includes a bundled version of OpenJDK within the `jdk` directory of the download that Elastisearch recommends be used.  Because of this, there is no need to manually install OpenJDK in the Docker images as Elastisearch not only already had it in the download (to see an example, download and uncompress https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.17.8-linux-x86_64.tar.gz) but is also set to use it by default.  So this PR removes the Docker commands to perform this install as it's not needed, makes the container builds faster, and removes the burden of keeping the OpenJDK up to date from the Dockerfile.

In addition, also updated Elastisearch inside the Docker containers to 7.17.8 as updating this version to deal with https://www.cve.org/CVERecord?id=CVE-2021-44228 that's mentioned in #386 has never been done.

## To Test
- To test the container in the `docker_containers/mindmeld_docker` directory, run `docker-compose up --build` from this directory.
- To test the container in the `docker_containers/mindmeld_dep_docker` directory, run `docker-compose up --build` from this directory.