### PR TITLE
Regenerate docs pages without cookie manager

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
         "augment": [
             'torch~=1.10.0; python_version>="3.6"',
             'transformers~=4.15.0; python_version>="3.6"',
-            'sentencepiece==0.1.91'
+            'sentencepiece==0.1.97'
         ],
         "language_annotator": [
             "google-cloud-translate>=3.0.1",

--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -1,14 +1,5 @@
 {% extends "!layout.html" %}
 
 {% block htmltitle %}
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-138982267-1"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'UA-138982267-1');
-  </script>
 {{ super() }}
 {% endblock %}

--- a/source/conf.py
+++ b/source/conf.py
@@ -114,7 +114,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"The Conversational AI Playbook"
-copyright = u"2019, Cisco Systems"
+copyright = u"2023, Cisco Systems"
 author = u"Cisco Systems."
 
 # The version info for the project you're documenting, acts as replacement for

--- a/source/userguide/deep_neural_nets.rst
+++ b/source/userguide/deep_neural_nets.rst
@@ -3,7 +3,7 @@ Deep Neural Networks in MindMeld
 
 Conversational AI and Natural Language Processing more generally have seen a boost in performance at a variety of tasks through the use of `Deep learning <https://en.wikipedia.org/wiki/Deep_learning>`_. In particular, deep neural models based on :wiki_api:`Convolutional neural networks (CNNs) <Convolutional_neural_network#Natural_language_processing>`, :wiki_api:`Long short-term memory networks (LSTM) <Long_short-term_memory>` and :wiki_api:`Transformers <Transformer_(machine_learning_model)>` architectures have been widely adopted over more traditional approaches to NLP to great success. MindMeld now extends its suite of traditional machine learning models (e.g. :sk_guide:`Logistic regression <linear_model.html#logistic-regression>`, :sk_guide:`Decision tree <tree.html#tree>`, etc.) with a variety of deep neural models and an array of configurable parameters.
 
-Users can now train and use deep neural models for :ref:`domain classification <domain_classification>` and :ref:`intent classification <intent_classification>` (aka. sequence classification) as well as for :ref:`entity recognition <entity_recognition>` (or token classification) tasks.
+Users can now train and use deep neural models for :ref:`domain classification <domain_classifier>` and :ref:`intent classification <intent_classifier>` (aka. sequence classification) as well as for :ref:`entity recognition <entity_recognizer>` (or token classification) tasks.
 
 .. note::
 

--- a/source/userguide/domain_classifier.rst
+++ b/source/userguide/domain_classifier.rst
@@ -1,7 +1,7 @@
 Working with the Domain Classifier
 ==================================
 
-.. _domain_classification:
+.. _domain_classifier:
 
 The Domain Classifier
 

--- a/source/userguide/entity_recognizer.rst
+++ b/source/userguide/entity_recognizer.rst
@@ -1,7 +1,7 @@
 Working with the Entity Recognizer
 ==================================
 
-.. _entity_recognition:
+.. _entity_recognizer:
 
 The :ref:`Entity Recognizer <arch_entity_model>`
 

--- a/source/userguide/intent_classifier.rst
+++ b/source/userguide/intent_classifier.rst
@@ -1,7 +1,7 @@
 Working with the Intent Classifier
 ==================================
 
-.. _intent_classification:
+.. _intent_classifier:
 
 The :ref:`Intent Classifier <arch_intent_model>`
 


### PR DESCRIPTION
1. Remove the cookie manager from the docs pages template
2. Update the copyright
3. Fix a few broken references from duplicate labels

Note: Does not include history notes for 4.6 and 4.7